### PR TITLE
Keep pagination 0-based

### DIFF
--- a/lambdas/src/lib.rs
+++ b/lambdas/src/lib.rs
@@ -110,7 +110,7 @@ pub fn pagination_parameters(event: &Request) -> Result<(u64, u64), ParseIntErro
     let page = event
         .query_string_parameters()
         .first("page")
-        .unwrap_or("1")
+        .unwrap_or("0")
         .parse::<u64>()?;
 
     // Ensure we do not allow the page to go above the max size.


### PR DESCRIPTION
Keeps the pagination 0-based to avoid off by one errors.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
