### PR TITLE
Add a Paginatron object

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [workspace]
-members = [".", "lambdas", "entity", "migration"]
+members = ["lambdas", "entity", "migration"]
 
 [dependencies]
 entity = { path = "entity" }

--- a/lambdas/src/link_header.rs
+++ b/lambdas/src/link_header.rs
@@ -171,7 +171,6 @@ impl<'a> Link<'a> {
 
 #[derive(Debug, PartialEq)]
 pub struct Rel<'a>(&'a str);
-
 #[derive(Debug, PartialEq)]
 pub struct Anchor<'a>(&'a str);
 #[derive(Debug, PartialEq)]

--- a/lambdas/tests/tests.hurl
+++ b/lambdas/tests/tests.hurl
@@ -1,10 +1,9 @@
-# Retrieves the first page of the bnas.
-GET {{host}}/bnas
-HTTP 200
-
 # Queries the first page of the bnas.
 GET {{host}}/bnas
+
 HTTP 200
+[Asserts]
+jsonpath "$" count > 0
 
 # Queries a the first page of the BNA with a page_size too big.
 # Ensures at most MAX_PAGE_SIZE is returned.
@@ -17,6 +16,7 @@ jsonpath "$" count <= {{max_page_size}}
 
 # Queries a the first page of the BNA with an invalid page number.
 GET {{host}}/bnas?page=-5
+
 HTTP 500
 
 # Queries a the first page of the BNA with a valid page number which does not exist.
@@ -28,20 +28,31 @@ jsonpath "$" count == 0
 
 # Queries a specific bna run.
 GET {{host}}/bnas/{{bna_id}}
+
 HTTP 200
 
 # Queries a specific bna run and its associated city.
 GET {{host}}/bnas/{{bna_id}}/city
+
 HTTP 200
+[Asserts]
+jsonpath "$" count > 0
 
 # Queries the first page of the cities.
 GET {{host}}/cities
+
 HTTP 200
+[Asserts]
+jsonpath "$" count > 0
 
 # Queries a specific city.
 GET {{host}}/cities/{{city_id}}
+
 HTTP 200
 
 # Queries all the BNAs of a specific city.
 GET {{host}}/cities/{{city_id}}/bnas
+
 HTTP 200
+[Asserts]
+jsonpath "$" count > 0

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}


### PR DESCRIPTION
Adds a Paginatron object to simplify computing pagination numbers and
links.

Drive-by:
- Adds more asserts to the integration tests.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
