### PR TITLE
Implement better errors

### DIFF
--- a/.github/workflows/lambdas.yml
+++ b/.github/workflows/lambdas.yml
@@ -26,6 +26,7 @@ jobs:
       - run: cargo fmt --check
       - run: cargo clippy -- -D warnings
       - run: cargo check
+      - run: cargo doc --no-deps
 
   test:
     runs-on: ubuntu-latest

--- a/lambdas/Cargo.toml
+++ b/lambdas/Cargo.toml
@@ -15,8 +15,10 @@ edition = "2021"
 # and it will keep the alphabetic ordering for you.
 
 [dependencies]
+aws_lambda_events = "0.8.5"
 dotenv = "0.15.0"
 entity = { path = "../entity" }
+http-serde = "1.1.2"
 lambda_http = "0.8"
 lambda_runtime = "0.8"
 nom = "7.1.3"
@@ -40,6 +42,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
 ] }
 url = "2.3.1"
 
+
 [[bin]]
 name = "get-bnas"
 path = "src/bnas/get-bnas.rs"
@@ -57,6 +60,7 @@ name = "get-cities-bnas"
 path = "src/cities/get-cities-bnas.rs"
 
 [dev-dependencies]
+query_map = "0.6.0"
 rstest = "0.17.0"
 
 [package.metadata.lambda.deploy]

--- a/lambdas/src/fixtures/get-request.json
+++ b/lambdas/src/fixtures/get-request.json
@@ -1,0 +1,18 @@
+{
+  "Request": {
+    "method": "GET",
+    "uri": "https://api.peopleforbikes.xyz/bnas/d84b4c38-cfda-40e3-9112-4fc80bebcd99",
+    "version": " HTTP/1.1",
+    "headers": {
+      "accept": "*/*",
+      "content-length": "0",
+      "host": "api.peopleforbikes.xyz",
+      "user-agent": "hurl/3.0.0",
+      "x-amzn-trace-id": "Root=1-6456b156-042437cb1036481a62468f00;Parent=d94786910896e863;Sampled=1;Lineage=4fa41f24:0",
+      "x-forwarded-for": "169.150.254.35",
+      "x-forwarded-port": "443",
+      "x-forwarded-proto": "https"
+    },
+    "body": "Empty"
+  }
+}

--- a/lambdas/tests/bnas.hurl
+++ b/lambdas/tests/bnas.hurl
@@ -37,22 +37,3 @@ GET {{host}}/bnas/{{bna_id}}/city
 HTTP 200
 [Asserts]
 jsonpath "$" count > 0
-
-# Queries the first page of the cities.
-GET {{host}}/cities
-
-HTTP 200
-[Asserts]
-jsonpath "$" count > 0
-
-# Queries a specific city.
-GET {{host}}/cities/{{city_id}}
-
-HTTP 200
-
-# Queries all the BNAs of a specific city.
-GET {{host}}/cities/{{city_id}}/bnas
-
-HTTP 200
-[Asserts]
-jsonpath "$" count > 0

--- a/lambdas/tests/cities.hurl
+++ b/lambdas/tests/cities.hurl
@@ -1,0 +1,18 @@
+# Queries the first page of the cities.
+GET {{host}}/cities
+
+HTTP 200
+[Asserts]
+jsonpath "$" count > 0
+
+# Queries a specific city.
+GET {{host}}/cities/{{city_id}}
+
+HTTP 200
+
+# Queries all the BNAs of a specific city.
+GET {{host}}/cities/{{city_id}}/bnas
+
+HTTP 200
+[Asserts]
+jsonpath "$" count > 0

--- a/lambdas/tests/justfile
+++ b/lambdas/tests/justfile
@@ -1,3 +1,3 @@
 # Run the integration tests against the stagging environment.
 test-staging:
-  hurl --variables-file staging.vars --test tests.hurl
+  hurl --variables-file staging.vars --test bnas.hurl cities.hurl


### PR DESCRIPTION
Implements more meaningful errors based on the type of problem
encountered.

The API now follows the JSON API specification described at
https://jsonapi.org/format/.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
