### PR TITLE
Improve integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
+.DS_Store
 *.pdb
 **/*.rs.bk
 /target
 Cargo.lock
 debug/
+lambdas/tests/.hypothesis
+lambdas/tests/.venv
 target/

--- a/lambdas/examples/dbconnect.rs
+++ b/lambdas/examples/dbconnect.rs
@@ -1,0 +1,13 @@
+use entity::bna;
+use sea_orm::{Database, DbErr, EntityTrait, PaginatorTrait};
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<(), DbErr> {
+    let db_url = env::var("DATABASE_URL").expect("DATABASE_URL is not set");
+    let db = Database::connect(db_url).await?;
+    let models = bna::Entity::find().paginate(&db, 10).fetch_page(0).await?;
+    dbg!(models);
+
+    Ok(())
+}

--- a/lambdas/requests.rest
+++ b/lambdas/requests.rest
@@ -32,3 +32,27 @@ GET {{host}}/cities/{{city_id}}
 
 # Query all the BNAs of a specific city.
 GET {{host}}/cities/{{city_id}}/bnas
+
+
+###
+# Bellow this point are the tests from schemathesis.
+###
+
+GET https://api.peopleforbikes.xyz/bnas/1
+X-Schemathesis-TestCaseId: 3bf4a72a4cc04ed589c5eedaf57b3ca2
+
+###
+GET https://api.peopleforbikes.xyz/bnas/0/city
+X-Schemathesis-TestCaseId: 9fa24d92de444fd28180df72fa1fabd6
+
+###
+GET https://api.peopleforbikes.xyz/cities
+X-Schemathesis-TestCaseId: 6c4cbf8880594f3d921ed1c3fe474a7f
+
+###
+GET https://api.peopleforbikes.xyz/cities/0
+X-Schemathesis-TestCaseId: 6c4cbf8880594f3d921ed1c3fe474a7f
+
+###
+GET https://api.peopleforbikes.xyz/cities/0/bnas
+X-Schemathesis-TestCaseId: 1f951094a7f14597bb50cafc52b812e0

--- a/lambdas/src/fixtures/api-gateway-payload-format-v2.json
+++ b/lambdas/src/fixtures/api-gateway-payload-format-v2.json
@@ -1,0 +1,63 @@
+{
+  "version": "2.0",
+  "routeKey": "$default",
+  "rawPath": "/my/path",
+  "rawQueryString": "parameter1=value1&parameter1=value2&parameter2=value",
+  "cookies": ["cookie1", "cookie2"],
+  "headers": {
+    "header1": "value1",
+    "header2": "value1,value2"
+  },
+  "queryStringParameters": {
+    "parameter1": "value1,value2",
+    "parameter2": "value"
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "apiId": "api-id",
+    "authentication": {
+      "clientCert": {
+        "clientCertPem": "CERT_CONTENT",
+        "subjectDN": "www.example.com",
+        "issuerDN": "Example issuer",
+        "serialNumber": "a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1",
+        "validity": {
+          "notBefore": "May 28 12:30:02 2019 GMT",
+          "notAfter": "Aug  5 09:36:04 2021 GMT"
+        }
+      }
+    },
+    "authorizer": {
+      "jwt": {
+        "claims": {
+          "claim1": "value1",
+          "claim2": "value2"
+        },
+        "scopes": ["scope1", "scope2"]
+      }
+    },
+    "domainName": "id.execute-api.us-east-1.amazonaws.com",
+    "domainPrefix": "id",
+    "http": {
+      "method": "POST",
+      "path": "/my/path",
+      "protocol": "HTTP/1.1",
+      "sourceIp": "192.0.2.1",
+      "userAgent": "agent"
+    },
+    "requestId": "id",
+    "routeKey": "$default",
+    "stage": "$default",
+    "time": "12/Mar/2020:19:03:58 +0000",
+    "timeEpoch": 1583348638390
+  },
+  "body": "Hello from Lambda",
+  "pathParameters": {
+    "parameter1": "value1"
+  },
+  "isBase64Encoded": false,
+  "stageVariables": {
+    "stageVariable1": "value1",
+    "stageVariable2": "value2"
+  }
+}

--- a/lambdas/src/fixtures/get-bnas-event.json
+++ b/lambdas/src/fixtures/get-bnas-event.json
@@ -1,0 +1,17 @@
+{
+  "method": "GET",
+  "uri": "https://api.peopleforbikes.xyz/bnas/0, version: HTTP/1.1",
+  "headers": {
+    "accept": "*/*",
+    "accept-encoding": "gzip, deflate",
+    "content-length": "0",
+    "host": "api.peopleforbikes.xyz",
+    "user-agent": "schemathesis/3.19.1",
+    "x-amzn-trace-id": "Root=1-644daf41-6fe263566fadf9fc52805a49;Parent=dcfd753bd2cd7f2a;Sampled=1;Lineage=4fa41f24:0",
+    "x-forwarded-for": "69.187.114.212",
+    "x-forwarded-port": "443",
+    "x-forwarded-proto": "https",
+    "x-schemathesis-testcaseid": "a95ac86fde714b3686e3d31b462e8e5e"
+  },
+  "body": null
+}

--- a/lambdas/src/lib.rs
+++ b/lambdas/src/lib.rs
@@ -110,10 +110,11 @@ pub fn pagination_parameters(event: &Request) -> Result<(u64, u64), Response<Bod
     {
         Ok(page_size) => page_size,
         Err(e) => {
-            return Err(Response::builder()
-                .status(StatusCode::BAD_REQUEST)
-                .body(format!("Failed to process the page_size parameter: {e}").into())
-                .unwrap())
+            let api_error = APIError::with_parameter(
+                "page_size",
+                format!("Failed to process the page_size parameter: {e}").as_str(),
+            );
+            return Err(APIErrors::new(&[api_error]).to_response());
         }
     };
     let page = match event
@@ -124,10 +125,11 @@ pub fn pagination_parameters(event: &Request) -> Result<(u64, u64), Response<Bod
     {
         Ok(page) => page,
         Err(e) => {
-            return Err(Response::builder()
-                .status(StatusCode::BAD_REQUEST)
-                .body(format!("Failed to process the page parameter: {e}").into())
-                .unwrap())
+            let api_error = APIError::with_parameter(
+                "page",
+                format!("Failed to process the page parameter: {e}").as_str(),
+            );
+            return Err(APIErrors::new(&[api_error]).to_response());
         }
     };
 
@@ -493,10 +495,8 @@ mod tests {
             Body::Text(message) => message,
             _ => panic!("The body does not match the Text invariant."),
         };
-        assert_eq!(
-            message,
-            "Failed to process the page_size parameter: invalid digit found in string"
-        );
+        let api_error: APIErrors = serde_json::from_str(message).unwrap();
+        assert_eq!(api_error.errors.len(), 1)
     }
 
     #[test]
@@ -520,9 +520,7 @@ mod tests {
             Body::Text(message) => message,
             _ => panic!("The body does not match the Text invariant."),
         };
-        assert_eq!(
-            message,
-            "Failed to process the page parameter: invalid digit found in string"
-        );
+        let api_error: APIErrors = serde_json::from_str(message).unwrap();
+        assert_eq!(api_error.errors.len(), 1)
     }
 }

--- a/lambdas/tests/bnas.hurl
+++ b/lambdas/tests/bnas.hurl
@@ -14,12 +14,14 @@ HTTP 200
 header "X-Per-Page" == "{{max_page_size}}"
 jsonpath "$" count <= {{max_page_size}}
 
-# Queries a the first page of the BNA with an invalid page number.
+# Queries the BNA with an invalid page number.
 GET {{host}}/bnas?page=-5
 
-HTTP 500
+HTTP 400
+[Asserts]
+jsonpath "$.errors" count == 1
 
-# Queries a the first page of the BNA with a valid page number which does not exist.
+# Queries the BNA with a valid page number but which does not exist.
 GET {{host}}/bnas?page=5000
 
 HTTP 200
@@ -31,9 +33,33 @@ GET {{host}}/bnas/{{bna_id}}
 
 HTTP 200
 
+# Queries a specific bna with an invalid id.
+GET {{host}}/bnas/1
+
+HTTP 400
+[Asserts]
+jsonpath "$.errors" count == 1
+jsonpath "$.errors[0].source.Parameter" == "bna_id"
+
+# Queries a non-existing bna run
+GET {{host}}/bnas/eac1dbfb-2137-44c5-be59-71fc613f2962
+
+HTTP 404
+[Asserts]
+jsonpath "$.errors" count == 1
+jsonpath "$.errors[0].source.Pointer" == "/bnas/eac1dbfb-2137-44c5-be59-71fc613f2962"
+
 # Queries a specific bna run and its associated city.
 GET {{host}}/bnas/{{bna_id}}/city
 
 HTTP 200
 [Asserts]
 jsonpath "$" count > 0
+
+# Queries a non-existing bna run and its associated city.
+GET {{host}}/bnas/374386aa-c34a-4cd6-b296-ae420017847e/city
+
+HTTP 404
+[Asserts]
+jsonpath "$.errors" count == 1
+jsonpath "$.errors[0].source.Pointer" == "/bnas/374386aa-c34a-4cd6-b296-ae420017847e/city"

--- a/lambdas/tests/cities.hurl
+++ b/lambdas/tests/cities.hurl
@@ -10,9 +10,27 @@ GET {{host}}/cities/{{city_id}}
 
 HTTP 200
 
+# Queries a non-existing city.
+GET {{host}}/cities/123456789
+
+HTTP 404
+[Asserts]
+jsonpath "$.errors" count == 1
+jsonpath "$.errors[0].source.Pointer" == "/cities/123456789"
+
 # Queries all the BNAs of a specific city.
 GET {{host}}/cities/{{city_id}}/bnas
 
 HTTP 200
 [Asserts]
 jsonpath "$" count > 0
+
+# Queries all the BNAs of a non-existing city.
+GET {{host}}/cities/0/bnas
+
+HTTP 404
+[Asserts]
+jsonpath "$.errors" count == 1
+jsonpath "$.errors[0].source.Pointer" == "/cities/0/bnas"
+
+

--- a/lambdas/tests/justfile
+++ b/lambdas/tests/justfile
@@ -1,3 +1,28 @@
+# Define variables.
+venv := ".venv"
+venv_bin := venv / "bin"
+activate := venv_bin / "activate"
+
+# Setup the project.
+setup:
+    test -d "{{ venv }}" || python3 -m venv {{ venv }}
+    . {{ activate }} \
+      && pip install --upgrade pip setuptools \
+      && pip install -r requirements.txt
+
+# Export the OpenAPI specification.
+openapi-export:
+  aws apigatewayv2 export-api \
+    --api-id ivyvugk79e \
+    --output-type YAML \
+    --specification OAS30 \
+    --no-include-extensions \
+    openapi.yaml
+
+# Run the schemathesis tests again the openapi schema.
+test-staging-schemathesis:
+  . {{ activate }} && st run openapi.yml --base-url https://api.peopleforbikes.xyz/
+
 # Run the integration tests against the stagging environment.
 test-staging:
   hurl --variables-file staging.vars --test bnas.hurl cities.hurl

--- a/lambdas/tests/openapi.yml
+++ b/lambdas/tests/openapi.yml
@@ -1,0 +1,80 @@
+openapi: "3.0.1"
+info:
+  title: "bna-api"
+  description: "BNA API"
+  version: "2023-04-21 00:58:00UTC"
+  license:
+    name: MIT
+    url: "https://api.peopleforbikes.xyz/{basePath}"
+tags:
+  - name: tag name
+    description: |
+      tag description.
+servers:
+  - url: "https://api.peopleforbikes.xyz/{basePath}"
+    variables:
+      basePath:
+        default: ""
+    x-amazon-apigateway-endpoint-configuration:
+      disableExecuteApiEndpoint: true
+paths:
+  /bnas:
+    get:
+      responses:
+        default:
+          description: "Default response for GET /bnas"
+  /bnas/{bna_id}:
+    get:
+      responses:
+        default:
+          description: "Default response for GET /bnas/{bna_id}"
+    parameters:
+      - name: "bna_id"
+        in: "path"
+        description: "Generated path parameter for bna_id"
+        required: true
+        schema:
+          type: "string"
+          format: "uuid"
+  /bnas/{bna_id}/city:
+    get:
+      responses:
+        default:
+          description: "Default response for GET /bnas/{bna_id}/city"
+    parameters:
+      - name: "bna_id"
+        in: "path"
+        description: "Generated path parameter for bna_id"
+        required: true
+        schema:
+          type: "string"
+          format: "uuid"
+  /cities:
+    get:
+      responses:
+        default:
+          description: "Default response for GET /cities"
+  /cities/{city_id}:
+    get:
+      responses:
+        default:
+          description: "Default response for GET /cities/{city_id}"
+    parameters:
+      - name: "city_id"
+        in: "path"
+        description: "Generated path parameter for city_id"
+        required: true
+        schema:
+          type: "string"
+  /cities/{city_id}/bnas:
+    get:
+      responses:
+        default:
+          description: "Default response for GET /cities/{city_id}/bnas"
+    parameters:
+      - name: "city_id"
+        in: "path"
+        description: "Generated path parameter for city_id"
+        required: true
+        schema:
+          type: "string"

--- a/lambdas/tests/requirements.txt
+++ b/lambdas/tests/requirements.txt
@@ -1,0 +1,1 @@
+schemathesis==3.19.1


### PR DESCRIPTION
- Adds schemathesis to do property testing against the OpenAPI spec.
- Adds more Hurl test cases and split the files by endpoints.

Drive-bys:
- Fixes /cities/{city_id}/bnas endpoint.
- Fixes error reponses from the pagination parameter parsing.
- Adds an example to test the database connection.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
