### PR TITLE
Update lambda fixtures

### DIFF
--- a/examples/query.rs
+++ b/examples/query.rs
@@ -2,11 +2,28 @@
 /// information about each of them.
 use color_eyre::{eyre::Report, Result};
 use dotenv::dotenv;
-use entity::city;
+use entity::recreation;
+use entity::{city, core_services, summary};
+use migration::Alias;
 use once_cell::sync::OnceCell;
-use sea_orm::{Database, DatabaseConnection, EntityTrait};
+use sea_orm::sea_query::Expr;
+use sea_orm::DbBackend;
+use sea_orm::FromQueryResult;
+use sea_orm::QueryTrait;
+use sea_orm::{
+    prelude::Uuid, Database, DatabaseConnection, EntityTrait, QuerySelect, RelationTrait,
+};
 
 static DATABASE_CONNECTION: OnceCell<DatabaseConnection> = OnceCell::new();
+
+#[derive(Debug, FromQueryResult)]
+struct BnaReport {
+    bna_uuid: Uuid,
+    city_id: Uuid,
+    score: f64,
+    cs_score: f64,
+    rec_score: f64,
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Report> {
@@ -17,19 +34,49 @@ async fn main() -> Result<(), Report> {
     let db = Database::connect(database_url).await?;
     DATABASE_CONNECTION.set(db).unwrap();
     let db = DATABASE_CONNECTION.get().unwrap();
+    let bna_uuid = Uuid::parse_str("18ca9450-2bfa-43a0-b8f3-2cd16952eba1").unwrap();
+    let summ: Option<BnaReport> = summary::Entity::find_by_id(bna_uuid)
+        .column(summary::Column::BnaUuid)
+        .column(summary::Column::CityId)
+        .column_as(core_services::Column::Score, "cs_score")
+        .column_as(recreation::Column::Score, "rec_score")
+        .join(
+            sea_orm::JoinType::InnerJoin,
+            summary::Relation::CoreServices.def(),
+        )
+        .join(
+            sea_orm::JoinType::InnerJoin,
+            summary::Relation::Infrastructure.def(),
+        )
+        .join(
+            sea_orm::JoinType::InnerJoin,
+            summary::Relation::Recreation.def(),
+        )
+        .join(
+            sea_orm::JoinType::InnerJoin,
+            summary::Relation::Opportunity.def(),
+        )
+        .join(
+            sea_orm::JoinType::InnerJoin,
+            summary::Relation::Features.def(),
+        )
+        // .build(DbBackend::Postgres)
+        // .to_string();
+        .into_model::<BnaReport>()
+        .one(db)
+        .await?;
 
-    // Retrieve cities and display some info.
-    match city::Entity::find().all(db).await {
-        Ok(city_models) => {
-            for city_model in city_models {
-                println!(
-                    "The city of {} with the id {} is localted in {}.",
-                    city_model.name, city_model.city_id, city_model.state
-                )
-            }
-        }
-        Err(error) => panic!("Cannot connect to the database: {}.", error.to_string()),
-    }
-
+    dbg!(summ);
     Ok(())
 }
+
+// SELECT SUMMARY.SCORE,
+// 	CORE_SERVICES.SCORE AS CSSCORE,
+// 	INFRASTRUCTURE.low_Stress_miles,
+// FROM SUMMARY
+// JOIN CORE_SERVICES ON CORE_SERVICES.BNA_UUID = SUMMARY.BNA_UUID
+// JOIN INFRASTRUCTURE ON INFRASTRUCTURE.BNA_UUID = SUMMARY.BNA_UUID
+// JOIN RECREATION ON RECREATION.BNA_UUID = SUMMARY.BNA_UUID
+// JOIN OPPORTUNITY ON OPPORTUNITY.BNA_UUID = SUMMARY.BNA_UUID
+// JOIN FEATURES ON FEATURES.BNA_UUID = SUMMARY.BNA_UUID
+// WHERE SUMMARY.BNA_UUID = '18ca9450-2bfa-43a0-b8f3-2cd16952eba1' ;

--- a/lambdas/README.md
+++ b/lambdas/README.md
@@ -8,7 +8,13 @@ Repository containing all the lambda endpoints for API Gateway.
 
 ## Testing
 
-2 terminal are required to test the functions.
+- 2 terminals are required to test the functions.
+- Start Docker Compose: `docker compose ud [-d]`
+- Export the database URL:
+
+  ```bash
+  export DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres
+  ```
 
 ### Terminal 1
 

--- a/lambdas/requests.rest
+++ b/lambdas/requests.rest
@@ -1,7 +1,7 @@
 @host=https://api.peopleforbikes.xyz
-@bna_id=d84b4c38-cfda-40e3-9112-4fc80bebcd99
-# Brooksville, FL.
-@city_id=1208800
+# Walla Walla, WA.
+@city_id=1c8f4f93-3537-4f31-ba0c-e165ebf67b74
+@bna_id=5864c9b6-ccb7-473f-a4fb-fec0345fc786
 
 ###
 

--- a/lambdas/src/fixtures/get-cities-bnas.json
+++ b/lambdas/src/fixtures/get-cities-bnas.json
@@ -1,6 +1,6 @@
 {
   "resource": "/cities/{city_id}/bnas/",
-  "path": "/cities/1208800/bnas/",
+  "path": "/cities/1c8f4f93-3537-4f31-ba0c-e165ebf67b74/bnas/",
   "httpMethod": "GET",
   "headers": {
     "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
@@ -43,7 +43,7 @@
   "queryStringParameters": null,
   "multiValueQueryStringParameters": null,
   "pathParameters": {
-    "city_id": "1208800"
+    "city_id": "1c8f4f93-3537-4f31-ba0c-e165ebf67b74"
   },
   "stageVariables": null,
   "requestContext": {


### PR DESCRIPTION
Updates lambda fixtures to reflect the new DB schema.

Drive-by:
- Updates the query example with a multiple join query to retrieve the
  full BNA report.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
