### PR TITLE
Add city enqueue endpoint

### DIFF
--- a/.github/workflows/deployment-staging.yml
+++ b/.github/workflows/deployment-staging.yml
@@ -39,6 +39,7 @@ jobs:
           get-bnas-cities
           get-cities
           get-cities-bnas
+          post-enqueue-city
           post-submissions-city"
           echo $LAMBDAS \
           | xargs -n1 -t \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,5 +28,4 @@ tokio = { version = "1", features = ["full"] }
 csv = "1.2.1"
 dotenv = "0.15.0"
 itertools = "0.12.0"
-# bnacore = { path = "/Users/rgreinhofer/projects/PeopleForBikes/brokenspoke/bnacore" }
-bnacore = { git = "https://github.com/PeopleForBikes/brokenspoke", rev = "6fa8808" }
+bnacore = { git = "https://github.com/PeopleForBikes/brokenspoke", rev = "98f20d7" }

--- a/lambdas/Cargo.toml
+++ b/lambdas/Cargo.toml
@@ -3,27 +3,19 @@ name = "lambdas"
 version = "0.1.0"
 edition = "2021"
 
-# Starting in Rust 1.62 you can use `cargo add` to add dependencies
-# to your project.
-#
-# If you're using an older Rust version,
-# download cargo-edit(https://github.com/killercup/cargo-edit#installation)
-# to install the `add` subcommand.
-#
-# Running `cargo add DEPENDENCY_NAME` will
-# add the latest version of a dependency to the list,
-# and it will keep the alphabetic ordering for you.
-
 [dependencies]
+aws-config = "1.0.0"
+aws-sdk-sqs = "0.39.0"
 aws_lambda_events = "0.12.0"
+bnacore = { git = "https://github.com/PeopleForBikes/brokenspoke.git", rev = "98f20d7" }
 dotenv = "0.15.0"
 entity = { path = "../entity" }
-http-serde = "1.1.2"
+http-serde = "1.1.3"
 lambda_http = "0.8"
 lambda_runtime = "0.8"
 nom = "7.1.3"
 once_cell = "1.17.1"
-reqwest = { version = "0.11.16", features = [
+reqwest = { version = "0.11.22", features = [
   "json",
   "native-tls-vendored",
   "rustls",
@@ -62,6 +54,10 @@ path = "src/cities/get-cities-bnas.rs"
 [[bin]]
 name = "post-submissions-city"
 path = "src/submissions/post-submissions-city.rs"
+
+[[bin]]
+name = "post-enqueue-city"
+path = "src/enqueue/post-city.rs"
 
 [dev-dependencies]
 rstest = "0.18.1"

--- a/lambdas/src/enqueue/post-city.rs
+++ b/lambdas/src/enqueue/post-city.rs
@@ -1,0 +1,81 @@
+use aws_config::BehaviorVersion;
+use aws_sdk_sqs::{self};
+use bnacore::aws::get_aws_parameter;
+use dotenv::dotenv;
+use lambda_http::{
+    http::StatusCode, run, service_fn, Body, Error, IntoResponse, Request, Response,
+};
+use lambdas::{get_apigw_request_id, APIError, APIErrorSource, APIErrors};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct EnqueueCity {
+    pub country: String,
+    pub city: String,
+    pub region: String,
+    pub fips_code: String,
+}
+
+async fn function_handler(event: Request) -> Result<Response<Body>, Error> {
+    dotenv().ok();
+
+    // Extract and serialize the data.
+    let apigw_request_id = get_apigw_request_id(&event);
+    let body = event.body();
+    let body_str = std::str::from_utf8(body).expect("invalid utf-8 sequence");
+    let enqueued_city = match serde_json::from_str::<EnqueueCity>(body_str) {
+        Ok(data) => data,
+        Err(e) => {
+            let api_error = APIError::new(
+                apigw_request_id,
+                StatusCode::BAD_REQUEST,
+                String::from("Invalid data"),
+                format!("The following submission is invalid: {body_str}. {e}"),
+                APIErrorSource::Pointer(event.uri().path().to_string()),
+            );
+            return Ok(APIErrors::new(&[api_error]).into());
+        }
+    };
+
+    // Prepare the AWS client.
+    let bna_sqs_queue = get_aws_parameter("BNA_SQS_QUEUE_URL").await?;
+    let aws_config = aws_config::load_defaults(BehaviorVersion::latest()).await;
+    let sqs_client = aws_sdk_sqs::Client::new(&aws_config);
+
+    // Enqueue the message.
+    let _send_message = match sqs_client
+        .send_message()
+        .queue_url(bna_sqs_queue)
+        .message_body(serde_json::to_string(&enqueued_city)?)
+        .send()
+        .await
+    {
+        Ok(message) => message,
+        Err(e) => {
+            let api_error = APIError::new(
+                apigw_request_id,
+                StatusCode::BAD_REQUEST,
+                String::from("Invalid data"),
+                format!("cannot enqueue the message: {e}"),
+                APIErrorSource::Pointer(event.uri().path().to_string()),
+            );
+            return Ok(APIErrors::new(&[api_error]).into());
+        }
+    };
+
+    Ok(json!(enqueued_city).into_response().await)
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        // disable printing the name of the module in every log line.
+        .with_target(false)
+        // disabling time is handy because CloudWatch will add the ingestion time.
+        .without_time()
+        .init();
+
+    run(service_fn(function_handler)).await
+}

--- a/lambdas/src/fixtures/post-enqueue-city.json
+++ b/lambdas/src/fixtures/post-enqueue-city.json
@@ -1,0 +1,63 @@
+{
+  "version": "2.0",
+  "routeKey": "$default",
+  "rawPath": "/enqueue/city",
+  "rawQueryString": "",
+  "cookies": null,
+  "headers": {
+    "header1": "value1",
+    "header2": "value1,value2"
+  },
+  "queryStringParameters": {
+    "parameter1": "value1,value2",
+    "parameter2": "value"
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "apiId": "api-id",
+    "authentication": {
+      "clientCert": {
+        "clientCertPem": "CERT_CONTENT",
+        "subjectDN": "www.example.com",
+        "issuerDN": "Example issuer",
+        "serialNumber": "a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1",
+        "validity": {
+          "notBefore": "May 28 12:30:02 2019 GMT",
+          "notAfter": "Aug  5 09:36:04 2021 GMT"
+        }
+      }
+    },
+    "authorizer": {
+      "jwt": {
+        "claims": {
+          "claim1": "value1",
+          "claim2": "value2"
+        },
+        "scopes": ["scope1", "scope2"]
+      }
+    },
+    "domainName": "id.execute-api.us-east-1.amazonaws.com",
+    "domainPrefix": "id",
+    "http": {
+      "method": "POST",
+      "path": "/enqueue/city",
+      "protocol": "HTTP/1.1",
+      "sourceIp": "192.0.2.1",
+      "userAgent": "agent"
+    },
+    "requestId": "id",
+    "routeKey": "$default",
+    "stage": "$default",
+    "time": "12/Mar/2020:19:03:58 +0000",
+    "timeEpoch": 1583348638390
+  },
+  "body": "{\"country\": \"usa\",\"city\": \"santa rosa\",\"region\": \"new mexico\",\"fips_code\": \"3570670\"}",
+  "pathParameters": {
+    "parameter1": "value1"
+  },
+  "isBase64Encoded": false,
+  "stageVariables": {
+    "stageVariable1": "value1",
+    "stageVariable2": "value2"
+  }
+}

--- a/lambdas/src/submissions/post-submissions-city.rs
+++ b/lambdas/src/submissions/post-submissions-city.rs
@@ -17,7 +17,6 @@ async fn function_handler(event: Request) -> Result<Response<Body>, Error> {
     let apigw_request_id = get_apigw_request_id(&event);
     let body = event.body();
     let body_str = std::str::from_utf8(body).expect("invalid utf-8 sequence");
-    dbg!(body_str);
     let model = match serde_json::from_str::<submission::Model>(body_str) {
         Ok(model) => model,
         Err(e) => {


### PR DESCRIPTION
Adds a new endpoint to enqueue a city onto the BNA pipeline queue.

The common functions were removed from `lib.rs` and pulled from the bnacore
library instead.

The staging deployment workflow and the lambda fixtures were adjsuted
accordingly.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
