### PR TITLE
Ensure Submission status is not NULL

### DIFF
--- a/entity/src/entities/submission.rs
+++ b/entity/src/entities/submission.rs
@@ -19,7 +19,7 @@ pub struct Model {
     pub region: Option<String>,
     pub fips_code: String,
     pub consent: bool,
-    pub status: Option<ApprovalStatus>,
+    pub status: ApprovalStatus,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/entity/src/wrappers/mod.rs
+++ b/entity/src/wrappers/mod.rs
@@ -32,7 +32,9 @@ impl IntoActiveModel<submission::ActiveModel> for Submission {
             region: ActiveValue::Set(self.region),
             fips_code: ActiveValue::Set(self.fips_code),
             consent: ActiveValue::Set(self.consent),
-            status: ActiveValue::Set(self.status),
+            status: self
+                .status
+                .map_or(ActiveValue::NotSet, |s| ActiveValue::Set(s)),
         }
     }
 }
@@ -53,7 +55,7 @@ mod tests {
         let region = Some("texas".to_string());
         let fips_code = "0123456".to_string();
         let consent = true;
-        let status = Some(ApprovalStatus::Pending);
+        let status = None;
         let wrapper = Submission {
             first_name: first_name.clone(),
             last_name: last_name.clone(),
@@ -80,7 +82,7 @@ mod tests {
             region: ActiveValue::Set(region),
             fips_code: ActiveValue::Set(fips_code),
             consent: ActiveValue::Set(consent),
-            status: ActiveValue::Set(status),
+            status: ActiveValue::NotSet,
         };
         assert_eq!(active_model, expected);
     }
@@ -97,7 +99,7 @@ mod tests {
         let region = None;
         let fips_code = "0123456".to_string();
         let consent = true;
-        let status = Some(ApprovalStatus::Pending);
+        let status = Some(ApprovalStatus::Approved);
         let wrapper = Submission {
             first_name: first_name.clone(),
             last_name: last_name.clone(),
@@ -124,7 +126,7 @@ mod tests {
             region: ActiveValue::Set(region),
             fips_code: ActiveValue::Set(fips_code),
             consent: ActiveValue::Set(consent),
-            status: ActiveValue::Set(status),
+            status: ActiveValue::Set(ApprovalStatus::Approved),
         };
         assert_eq!(active_model, expected);
     }

--- a/migration/src/m20231010_232527_city_submission.rs
+++ b/migration/src/m20231010_232527_city_submission.rs
@@ -48,6 +48,7 @@ impl MigrationTrait for Migration {
                     .col(
                         ColumnDef::new(Submission::Status)
                             .enumeration(ApprovalStatus::Table, ApprovalStatus::iter().skip(1))
+                            .not_null()
                             .default(ApprovalStatus::Pending.to_string()),
                     )
                     .to_owned(),


### PR DESCRIPTION
Updates the database schema to ensure that the status of a Submission
can never be `NULL`, but is always set to one of the possible values
from the Enum.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
