### PR TITLE
Add ability to update Submission

### DIFF
--- a/entity/src/wrappers/mod.rs
+++ b/entity/src/wrappers/mod.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Submission {
+    pub id: Option<i32>,
     pub first_name: String,
     pub last_name: String,
     pub title: Option<String>,
@@ -21,7 +22,7 @@ pub struct Submission {
 impl IntoActiveModel<submission::ActiveModel> for Submission {
     fn into_active_model(self) -> submission::ActiveModel {
         submission::ActiveModel {
-            id: ActiveValue::NotSet,
+            id: self.id.map_or(ActiveValue::NotSet, ActiveValue::Set),
             first_name: ActiveValue::Set(self.first_name),
             last_name: ActiveValue::Set(self.last_name),
             title: ActiveValue::Set(self.title),
@@ -32,9 +33,7 @@ impl IntoActiveModel<submission::ActiveModel> for Submission {
             region: ActiveValue::Set(self.region),
             fips_code: ActiveValue::Set(self.fips_code),
             consent: ActiveValue::Set(self.consent),
-            status: self
-                .status
-                .map_or(ActiveValue::NotSet, |s| ActiveValue::Set(s)),
+            status: self.status.map_or(ActiveValue::NotSet, ActiveValue::Set),
         }
     }
 }
@@ -57,6 +56,7 @@ mod tests {
         let consent = true;
         let status = None;
         let wrapper = Submission {
+            id: None,
             first_name: first_name.clone(),
             last_name: last_name.clone(),
             title: title.clone(),
@@ -101,6 +101,7 @@ mod tests {
         let consent = true;
         let status = Some(ApprovalStatus::Approved);
         let wrapper = Submission {
+            id: None,
             first_name: first_name.clone(),
             last_name: last_name.clone(),
             title: title.clone(),

--- a/lambdas/src/cities-submissions/post-cities-submissions.rs
+++ b/lambdas/src/cities-submissions/post-cities-submissions.rs
@@ -20,7 +20,7 @@ async fn function_handler(event: Request) -> Result<Response<Body>, Error> {
     let body_str = std::str::from_utf8(body).expect("invalid utf-8 sequence");
     info!(body_str);
     let wrapper = match serde_json::from_str::<wrappers::Submission>(body_str) {
-        Ok(model) => model,
+        Ok(wrapper) => wrapper,
         Err(e) => {
             let api_error = APIError::new(
                 apigw_request_id,
@@ -33,16 +33,29 @@ async fn function_handler(event: Request) -> Result<Response<Body>, Error> {
         }
     };
 
-    // Turn the model wrapper into an active model and unset the primary key.
+    // Turn the model wrapper into an active model.
     let active_submission = wrapper.into_active_model();
-    info!(
-        "inserting Submission into database: {:?}",
-        active_submission
-    );
 
-    // Insert the submission into the database.
-    let res = Submission::insert(active_submission).exec(&db).await?;
-    Ok(json!(res.last_insert_id).into_response().await)
+    // And insert a new entry or update an existing one.
+    if active_submission.id.is_not_set() {
+        info!(
+            "inserting Submission into database: {:?}",
+            active_submission
+        );
+
+        // Insert the Submission into the database.
+        let res = Submission::insert(active_submission).exec(&db).await?;
+        Ok(json!(res.last_insert_id).into_response().await)
+    } else {
+        info!(
+            "updating Submission {:?} into database: {:?}",
+            active_submission.id, active_submission
+        );
+
+        // Update the Submission entryq.
+        let res = Submission::update(active_submission).exec(&db).await?;
+        Ok(json!(res.id).into_response().await)
+    }
 }
 
 #[tokio::main]


### PR DESCRIPTION
Modifies the Submissions endpoint to give the ability to update an
existing entry.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
