### PR TITLE
Fix Submissions Endpoints

### DIFF
--- a/lambdas/src/cities-submissions/get-cities-submissions.rs
+++ b/lambdas/src/cities-submissions/get-cities-submissions.rs
@@ -32,20 +32,12 @@ async fn function_handler(event: Request) -> Result<Response<Body>, Error> {
     // Retrieve the status parameter if available.
     let query_param_key = "status";
     match parse_query_string_parameter::<wrappers::ApprovalStatus>(&event, query_param_key) {
-        Ok(status) => match status {
-            Some(status) => {
+        Ok(status) => {
+            if let Some(status) = status {
                 let s: entity::sea_orm_active_enums::ApprovalStatus = status.into();
                 conditions = conditions.add(entity::submission::Column::Status.eq(s))
             }
-            None => {
-                let api_error = APIError::with_parameter(
-                    get_apigw_request_id(&event),
-                    query_param_key,
-                    format!("{query_param_key} parameter not found").as_str(),
-                );
-                return Ok(APIErrors::new(&[api_error]).into());
-            }
-        },
+        }
         Err(e) => return Ok(e.into()),
     }
 

--- a/lambdas/src/cities-submissions/patch-cities-submissions.rs
+++ b/lambdas/src/cities-submissions/patch-cities-submissions.rs
@@ -1,6 +1,9 @@
 use dotenv::dotenv;
-use effortless::api::{missing_parameter, parse_path_parameter, parse_request_body};
-use entity::{prelude::*, wrappers};
+use effortless::{
+    api::{missing_parameter, parse_path_parameter, parse_request_body},
+    error::APIErrors,
+};
+use entity::{prelude::*, submission::ActiveModel, wrappers};
 use lambda_http::{run, service_fn, Body, Error, IntoResponse, Request, Response};
 use lambdas::database_connect;
 use sea_orm::{ActiveValue, EntityTrait, IntoActiveModel};
@@ -10,30 +13,14 @@ use tracing::info;
 async fn function_handler(event: Request) -> Result<Response<Body>, Error> {
     dotenv().ok();
 
-    // Retrieve the ID of the Submission to update.
-    let parameter = "id";
-    let submission_id = match parse_path_parameter::<i32>(&event, parameter) {
-        Ok(value) => match value {
-            Some(v) => v,
-            None => {
-                return Ok(missing_parameter(&event, parameter).into());
-            }
-        },
+    // Retrieve the model to update.
+    let active_submission = match prepare_active_model(&event) {
+        Ok(submission) => submission,
         Err(e) => return Ok(e.into()),
     };
-
-    // Extract and deserialize the data.
-    let wrapper = match parse_request_body::<wrappers::Submission>(&event) {
-        Ok(value) => value,
-        Err(e) => return Ok(e.into()),
-    };
-
-    // Turn the wrapper into an active model.
-    let mut active_submission = wrapper.into_active_model();
-    active_submission.id = ActiveValue::Set(submission_id);
     info!(
-        "updating Submission {submission_id} into database: {:?}",
-        active_submission
+        "updating Submission {:?} into database: {:?}",
+        active_submission.id, active_submission
     );
 
     // Get the database connection.
@@ -55,4 +42,49 @@ async fn main() -> Result<(), Error> {
         .init();
 
     run(service_fn(function_handler)).await
+}
+
+pub fn prepare_active_model(event: &Request) -> Result<ActiveModel, APIErrors> {
+    // Retrieve the ID of the Submission to update.
+    let parameter = "id";
+    let submission_id = match parse_path_parameter::<i32>(event, parameter) {
+        Ok(value) => match value {
+            Some(v) => v,
+            None => {
+                return Err(missing_parameter(event, parameter).into());
+            }
+        },
+        Err(e) => return Err(e),
+    };
+
+    // Extract and deserialize the data.
+    let wrapper = match parse_request_body::<wrappers::Submission>(event) {
+        Ok(value) => value,
+        Err(e) => return Err(e),
+    };
+
+    // Turn the wrapper into an active model.
+    let mut active_submission = wrapper.into_active_model();
+    active_submission.id = ActiveValue::Set(submission_id);
+    Ok(active_submission)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lambda_http::RequestExt;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_prepare_active_model() {
+        let event = Request::new("{\"city\":\"santa rosa\",\"consent\":true,\"country\":\"usa\",\"email\":\"jane.dpe@orgllc.com\",\"fips_code\":\"3570670\",\"first_name\":\"Jane\",\"id\":1,\"last_name\":\"Doe\",\"organization\":\"Organization LLC\",\"region\":\"new mexico\",\"status\":\"Approved\",\"title\":\"CTO\"}"
+        .into()).with_path_parameters(HashMap::from([("id".to_string(), "1".to_string())])).with_request_context(lambda_http::request::RequestContext::ApiGatewayV2(
+        lambda_http::aws_lambda_events::apigw::ApiGatewayV2httpRequestContext::default(),
+    ));
+        let active_submission = prepare_active_model(&event).unwrap();
+        assert_eq!(
+            active_submission.country,
+            sea_orm::ActiveValue::Set("usa".to_string())
+        )
+    }
 }


### PR DESCRIPTION
Fixes the GET Submissions endpoint by making the `status` query string
optional.

Refactors the PATCH Submissions and add unit tests.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
