### PR TITLE
Refactor Submission Wrappers

### DIFF
--- a/entity/src/wrappers/mod.rs
+++ b/entity/src/wrappers/mod.rs
@@ -5,41 +5,6 @@ use crate::entities::submission;
 use sea_orm::{ActiveValue, IntoActiveModel};
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Submission {
-    pub id: Option<i32>,
-    pub first_name: String,
-    pub last_name: String,
-    pub title: Option<String>,
-    pub organization: Option<String>,
-    pub email: String,
-    pub country: String,
-    pub city: String,
-    pub region: Option<String>,
-    pub fips_code: String,
-    pub consent: bool,
-    pub status: Option<sea_orm_active_enums::ApprovalStatus>,
-}
-
-impl IntoActiveModel<submission::ActiveModel> for Submission {
-    fn into_active_model(self) -> submission::ActiveModel {
-        submission::ActiveModel {
-            id: self.id.map_or(ActiveValue::NotSet, ActiveValue::Set),
-            first_name: ActiveValue::Set(self.first_name),
-            last_name: ActiveValue::Set(self.last_name),
-            title: ActiveValue::Set(self.title),
-            organization: ActiveValue::Set(self.organization),
-            email: ActiveValue::Set(self.email),
-            country: ActiveValue::Set(self.country),
-            city: ActiveValue::Set(self.city),
-            region: ActiveValue::Set(self.region),
-            fips_code: ActiveValue::Set(self.fips_code),
-            consent: ActiveValue::Set(self.consent),
-            status: self.status.map_or(ActiveValue::NotSet, ActiveValue::Set),
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ApprovalStatus {
     Approved,
@@ -74,13 +39,86 @@ impl FromStr for ApprovalStatus {
         serde_plain::from_str::<Self>(s)
     }
 }
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SubmissionPost {
+    pub id: Option<i32>,
+    pub first_name: String,
+    pub last_name: String,
+    pub title: Option<String>,
+    pub organization: Option<String>,
+    pub email: String,
+    pub country: String,
+    pub city: String,
+    pub region: Option<String>,
+    pub fips_code: String,
+    pub consent: bool,
+    pub status: Option<sea_orm_active_enums::ApprovalStatus>,
+}
+
+impl IntoActiveModel<submission::ActiveModel> for SubmissionPost {
+    fn into_active_model(self) -> submission::ActiveModel {
+        submission::ActiveModel {
+            id: self.id.map_or(ActiveValue::NotSet, ActiveValue::Set),
+            first_name: ActiveValue::Set(self.first_name),
+            last_name: ActiveValue::Set(self.last_name),
+            title: ActiveValue::Set(self.title),
+            organization: ActiveValue::Set(self.organization),
+            email: ActiveValue::Set(self.email),
+            country: ActiveValue::Set(self.country),
+            city: ActiveValue::Set(self.city),
+            region: ActiveValue::Set(self.region),
+            fips_code: ActiveValue::Set(self.fips_code),
+            consent: ActiveValue::Set(self.consent),
+            status: self.status.map_or(ActiveValue::NotSet, ActiveValue::Set),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SubmissionPatch {
+    pub id: Option<i32>,
+    pub first_name: Option<String>,
+    pub last_name: Option<String>,
+    pub title: Option<Option<String>>,
+    pub organization: Option<Option<String>>,
+    pub email: Option<String>,
+    pub country: Option<String>,
+    pub city: Option<String>,
+    pub region: Option<Option<String>>,
+    pub fips_code: Option<String>,
+    pub consent: Option<bool>,
+    pub status: Option<sea_orm_active_enums::ApprovalStatus>,
+}
+
+impl IntoActiveModel<submission::ActiveModel> for SubmissionPatch {
+    fn into_active_model(self) -> submission::ActiveModel {
+        submission::ActiveModel {
+            id: self.id.map_or(ActiveValue::NotSet, ActiveValue::Unchanged),
+            first_name: self
+                .first_name
+                .map_or(ActiveValue::NotSet, ActiveValue::Set),
+            last_name: self.last_name.map_or(ActiveValue::NotSet, ActiveValue::Set),
+            title: self.title.map_or(ActiveValue::NotSet, ActiveValue::Set),
+            organization: self
+                .organization
+                .map_or(ActiveValue::NotSet, ActiveValue::Set),
+            email: self.email.map_or(ActiveValue::NotSet, ActiveValue::Set),
+            country: self.country.map_or(ActiveValue::NotSet, ActiveValue::Set),
+            city: self.city.map_or(ActiveValue::NotSet, ActiveValue::Set),
+            region: self.region.map_or(ActiveValue::NotSet, ActiveValue::Set),
+            fips_code: self.fips_code.map_or(ActiveValue::NotSet, ActiveValue::Set),
+            consent: self.consent.map_or(ActiveValue::NotSet, ActiveValue::Set),
+            status: self.status.map_or(ActiveValue::NotSet, ActiveValue::Set),
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn test_submission_into_active_model_full() {
+    fn test_submission_post_into_active_model_full() {
         let first_name = "John".to_string();
         let last_name = "Doe".to_string();
         let title = Some("Director".to_owned());
@@ -92,7 +130,7 @@ mod tests {
         let fips_code = "0123456".to_string();
         let consent = true;
         let status = None;
-        let wrapper = Submission {
+        let wrapper = SubmissionPost {
             id: None,
             first_name: first_name.clone(),
             last_name: last_name.clone(),
@@ -125,7 +163,7 @@ mod tests {
     }
 
     #[test]
-    fn test_submission_into_active_model_required_only() {
+    fn test_submission_post_into_active_model_required_only() {
         let first_name = "John".to_string();
         let last_name = "Doe".to_string();
         let title = None;
@@ -137,7 +175,7 @@ mod tests {
         let fips_code = "0123456".to_string();
         let consent = true;
         let status = Some(sea_orm_active_enums::ApprovalStatus::Approved);
-        let wrapper = Submission {
+        let wrapper = SubmissionPost {
             id: None,
             first_name: first_name.clone(),
             last_name: last_name.clone(),
@@ -165,6 +203,42 @@ mod tests {
             fips_code: ActiveValue::Set(fips_code),
             consent: ActiveValue::Set(consent),
             status: ActiveValue::Set(sea_orm_active_enums::ApprovalStatus::Approved),
+        };
+        assert_eq!(active_model, expected);
+    }
+
+    #[test]
+    fn test_submission_patch_into_model() {
+        let id = 42;
+        let first_name = "John".to_string();
+        let wrapper = SubmissionPatch {
+            id: Some(id),
+            first_name: Some(first_name.clone()),
+            last_name: None,
+            title: None,
+            organization: None,
+            email: None,
+            country: None,
+            city: None,
+            region: None,
+            fips_code: None,
+            consent: None,
+            status: None,
+        };
+        let active_model = wrapper.into_active_model();
+        let expected = submission::ActiveModel {
+            id: ActiveValue::Unchanged(id),
+            first_name: ActiveValue::Set(first_name),
+            last_name: ActiveValue::NotSet,
+            title: ActiveValue::NotSet,
+            organization: ActiveValue::NotSet,
+            email: ActiveValue::NotSet,
+            country: ActiveValue::NotSet,
+            city: ActiveValue::NotSet,
+            region: ActiveValue::NotSet,
+            fips_code: ActiveValue::NotSet,
+            consent: ActiveValue::NotSet,
+            status: ActiveValue::NotSet,
         };
         assert_eq!(active_model, expected);
     }

--- a/lambdas/src/cities-submissions/post-cities-submissions.rs
+++ b/lambdas/src/cities-submissions/post-cities-submissions.rs
@@ -11,7 +11,7 @@ async fn function_handler(event: Request) -> Result<Response<Body>, Error> {
     dotenv().ok();
 
     // Extract and serialize the data.
-    let wrapper = match parse_request_body::<wrappers::Submission>(&event) {
+    let wrapper = match parse_request_body::<wrappers::SubmissionPost>(&event) {
         Ok(value) => value,
         Err(e) => return Ok(e.into()),
     };

--- a/lambdas/src/lib.rs
+++ b/lambdas/src/lib.rs
@@ -295,7 +295,7 @@ pub async fn api_database_connect(event: &Request) -> APIResult<DatabaseConnecti
 mod tests {
     use super::*;
     use effortless::api::{parse_path_parameter, parse_request_body};
-    use entity::wrappers::Submission;
+    use entity::wrappers::SubmissionPost;
     use lambda_http::{http::StatusCode, request::from_str, RequestExt};
     use std::collections::HashMap;
 
@@ -418,7 +418,7 @@ mod tests {
     #[test]
     fn test_parse_request_body() {
         let event = Request::new("{\n  \"city\": \"santa rosa\",\n  \"country\": \"usa\",\n  \"email\": \"jane.dpe@orgllc.com\",\n  \"fips_code\": \"3570670\",\n  \"first_name\": \"Jane\",\n  \"last_name\": \"Doe\",\n  \"organization\": \"Organization LLC\",\n  \"region\": \"new mexico\",\n  \"title\": \"CTO\",\n  \"consent\": true\n}".into());
-        let submission = parse_request_body::<Submission>(&event).unwrap();
+        let submission = parse_request_body::<SubmissionPost>(&event).unwrap();
         assert_eq!(submission.country, "usa")
     }
 
@@ -427,7 +427,7 @@ mod tests {
         let event = Request::new("{\n  \"city\": \"santa rosa\",\n  \"country\": \"usa\",\n  \"email\": \"jane.dpe@orgllc.com\",\n  \"fips_code\": \"3570670\",\n  \"first_name\": \"Jane\",\n  \"last_name\": \"Doe\",\n  \"organization\": \"Organization LLC\",\n  \"region\": \"new mexico\",\n  \"title\": \"CTO\",\n  \"consent\": true\n}".into()).with_request_context(lambda_http::request::RequestContext::ApiGatewayV2(
           lambda_http::aws_lambda_events::apigw::ApiGatewayV2httpRequestContext::default(),
       ));
-        let submission = parse_request_body::<Submission>(&event).unwrap();
+        let submission = parse_request_body::<SubmissionPost>(&event).unwrap();
         assert_eq!(submission.country, "usa")
     }
 }


### PR DESCRIPTION
Implement new wrappers for the POST and PATCH methods.

Drive-by:
- Simplifies the patch-cities-submissions lambda.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
