### PR TITLE
Fix PATCH endpoint for /bnas/analysis

### DIFF
--- a/entity/src/wrappers/mod.rs
+++ b/entity/src/wrappers/mod.rs
@@ -183,7 +183,6 @@ impl IntoActiveModel<brokenspoke_pipeline::ActiveModel> for BrokenspokePipelineP
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BrokenspokePipelinePatch {
     pub state: Option<Option<sea_orm_active_enums::BrokenspokeState>>,
-    pub state_machine_id: Uuid,
     pub scheduled_trigger_id: Option<Option<Uuid>>,
     pub sqs_message: Option<Option<Json>>,
     pub neon_branch_id: Option<Option<String>>,
@@ -194,8 +193,8 @@ pub struct BrokenspokePipelinePatch {
 impl IntoActiveModel<brokenspoke_pipeline::ActiveModel> for BrokenspokePipelinePatch {
     fn into_active_model(self) -> brokenspoke_pipeline::ActiveModel {
         brokenspoke_pipeline::ActiveModel {
+            state_machine_id: ActiveValue::NotSet,
             state: self.state.map_or(ActiveValue::NotSet, ActiveValue::Set),
-            state_machine_id: ActiveValue::Unchanged(self.state_machine_id),
             sqs_message: self
                 .sqs_message
                 .map_or(ActiveValue::NotSet, ActiveValue::Set),

--- a/lambdas/requests.rest
+++ b/lambdas/requests.rest
@@ -136,7 +136,7 @@ Authorization: Bearer {{cognito_access}}
   "status": "Accepted"
 }
 
-@state_machine_id=166680c0-4e74-409b-b095-ae45ae458f0
+@state_machine_id=e6aade5a-b343-120b-dbaa-bd916cd99221
 
 ### Create a new BNA analysis performed by the Brokenspoke-analyzer pipeline.
 POST {{host}}/bnas/analysis


### PR DESCRIPTION
Fixes the patch endpoint for /bnas/analysis to ensure it can update an
exisiting entry without overriding the primary key.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
