### PR TITLE
Use time crate to manage date/time objects

### DIFF
--- a/entity/src/entities/brokenspoke_pipeline.rs
+++ b/entity/src/entities/brokenspoke_pipeline.rs
@@ -16,8 +16,8 @@ pub struct Model {
     pub neon_branch_id: Option<String>,
     pub fargate_task_arn: Option<String>,
     pub s3_bucket: Option<String>,
-    pub start_time: DateTimeWithTimeZone,
-    pub end_time: Option<DateTimeWithTimeZone>,
+    pub start_time: TimeDateTimeWithTimeZone,
+    pub end_time: Option<TimeDateTimeWithTimeZone>,
     pub torn_down: Option<bool>,
 }
 

--- a/entity/src/entities/census.rs
+++ b/entity/src/entities/census.rs
@@ -9,7 +9,7 @@ pub struct Model {
     #[sea_orm(primary_key)]
     pub census_id: i32,
     pub city_id: Uuid,
-    pub created_at: Option<DateTimeWithTimeZone>,
+    pub created_at: Option<TimeDateTimeWithTimeZone>,
     pub fips_code: String,
     pub pop_size: i32,
     pub population: i32,

--- a/entity/src/entities/ranking.rs
+++ b/entity/src/entities/ranking.rs
@@ -11,7 +11,7 @@ pub struct Model {
     pub city_id: Uuid,
     pub country: String,
     pub country_size: i32,
-    pub created_at: Option<DateTimeWithTimeZone>,
+    pub created_at: Option<TimeDateTimeWithTimeZone>,
     pub global: i32,
     pub size: i32,
     pub state: i32,

--- a/entity/src/entities/speed_limit.rs
+++ b/entity/src/entities/speed_limit.rs
@@ -9,7 +9,7 @@ pub struct Model {
     #[sea_orm(primary_key)]
     pub speed_limit_id: i32,
     pub city_id: Uuid,
-    pub created_at: Option<DateTimeWithTimeZone>,
+    pub created_at: Option<TimeDateTimeWithTimeZone>,
     pub residential: i32,
 }
 

--- a/entity/src/entities/summary.rs
+++ b/entity/src/entities/summary.rs
@@ -9,7 +9,7 @@ pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub bna_uuid: Uuid,
     pub city_id: Uuid,
-    pub created_at: Option<DateTimeWithTimeZone>,
+    pub created_at: Option<TimeDateTimeWithTimeZone>,
     #[sea_orm(column_type = "Double")]
     pub score: f64,
     pub version: String,

--- a/entity/src/wrappers/mod.rs
+++ b/entity/src/wrappers/mod.rs
@@ -1,6 +1,6 @@
 use crate::entities::{brokenspoke_pipeline, sea_orm_active_enums, submission};
 use sea_orm::{
-    prelude::{DateTimeWithTimeZone, Json, Uuid},
+    prelude::{Json, TimeDateTimeWithTimeZone, Uuid},
     ActiveValue, IntoActiveModel,
 };
 use serde::{Deserialize, Serialize};
@@ -160,8 +160,8 @@ pub struct BrokenspokePipelinePost {
     pub neon_branch_id: Option<String>,
     pub fargate_task_arn: Option<String>,
     pub s3_bucket: Option<String>,
-    pub start_time: DateTimeWithTimeZone,
-    pub end_time: Option<DateTimeWithTimeZone>,
+    pub start_time: TimeDateTimeWithTimeZone,
+    pub end_time: Option<TimeDateTimeWithTimeZone>,
     pub torn_down: Option<bool>,
 }
 
@@ -190,8 +190,8 @@ pub struct BrokenspokePipelinePatch {
     pub neon_branch_id: Option<Option<String>>,
     pub fargate_task_arn: Option<Option<String>>,
     pub s3_bucket: Option<Option<String>>,
-    pub start_time: Option<Option<DateTimeWithTimeZone>>,
-    pub end_time: Option<Option<DateTimeWithTimeZone>>,
+    pub start_time: Option<Option<TimeDateTimeWithTimeZone>>,
+    pub end_time: Option<Option<TimeDateTimeWithTimeZone>>,
     pub torn_down: Option<Option<bool>>,
 }
 

--- a/justfile
+++ b/justfile
@@ -35,7 +35,7 @@ lint-spellcheck:
 # Generate models
 db-generate-models:
     rm -fr  {{ entites }}
-    sea-orm-cli generate entity -o {{ entites }} --with-serde both
+    sea-orm-cli generate entity -o {{ entites }} --with-serde both --date-time-crate time
 
 
 # Apply migrations and seed the database.


### PR DESCRIPTION
Uses the `time` crate to manage date/time objects instead of the chrono
crate.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
