### PR TITLE
URL decode parameters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,40 +8,42 @@ publish = false
 members = ["lambdas", "entity", "migration", "effortless"]
 
 [workspace.dependencies]
-color-eyre = "0.6.2"
+async-std = "1"
+aws_lambda_events = "0.15.0"
+aws-config = "1.0.0"
+aws-sdk-s3 = "1.5.0"
+aws-sdk-sqs = "1.3.0"
 chrono = "0.4.24"
+color-eyre = "0.6.2"
+csv = "1.3.0"
 dotenv = "0.15.0"
 entity = { path = "entity" }
 futures = "0.3.21"
 http-serde = "2.0.0"
+itertools = "0.12.1"
 lambda_http = "0.11.0"
+lambda_runtime = "0.11.0"
 migration = { path = "migration" }
+nom = "7.1.3"
 once_cell = "1.17.1"
+reqwest = "0.12.1"
+rstest = "0.19.0"
 sea-orm = "0.12.1"
+sea-orm-migration = "0.12.1"
 serde = "1.0.159"
 serde_json = "1.0.95"
 serde_plain = "1.0.2"
 serde_with = "3.4.0"
+thiserror = "1"
 tokio = "1"
-async-std = "1"
-aws-config = "1.0.0"
-aws-sdk-s3 = "1.5.0"
-aws-sdk-sqs = "1.3.0"
-aws_lambda_events = "0.15.0"
-csv = "1.3.0"
-itertools = "0.12.1"
-lambda_runtime = "0.11.0"
-nom = "7.1.3"
-reqwest = "0.12.1"
-rstest = "0.19.0"
-sea-orm-migration = "0.12.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false }
 url = "2.3.1"
+urlencoding = "2.1.3"
 
 [dependencies]
-color-eyre = { workspace = true }
 chrono = { workspace = true }
+color-eyre = { workspace = true }
 dotenv = { workspace = true }
 entity = { workspace = true }
 futures = { workspace = true }

--- a/effortless/Cargo.toml
+++ b/effortless/Cargo.toml
@@ -13,3 +13,5 @@ lambda_http = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
+thiserror = { workspace = true }
+urlencoding = { workspace = true }

--- a/lambdas/requests.rest
+++ b/lambdas/requests.rest
@@ -2,9 +2,9 @@
 # Walla Walla, WA.
 @city_id=1c8f4f93-3537-4f31-ba0c-e165ebf67b74
 @bna_id=1a759b85-cd87-4bb1-9efa-5789e38e9982
-@country=usa
-@region=texas
-@name=austin
+@country=United States
+@region=Texas
+@name=Austin
 
 ###
 # Query the first page of the bnas.

--- a/lambdas/src/cities/get-cities-bnas.rs
+++ b/lambdas/src/cities/get-cities-bnas.rs
@@ -23,6 +23,7 @@ async fn function_handler(event: Request) -> Result<Response<Body>, Error> {
         Ok(value) => value,
         Err(e) => return Ok(e.into()),
     };
+    dbg!(&country);
     let region = match parse_path_parameter::<String>(&event, "region") {
         Ok(value) => value,
         Err(e) => return Ok(e.into()),
@@ -64,4 +65,36 @@ async fn main() -> Result<(), Error> {
         info!("{e}");
         e
     })
+}
+
+#[cfg(test)]
+mod tests {
+    // use super::*;
+    // use lambda_http::{http, RequestExt};
+    // use std::collections::HashMap;
+
+    // #[tokio::test]
+    // async fn test_handler_opportunity() {
+    //     let event = http::Request::builder()
+    //         .header(http::header::CONTENT_TYPE, "application/json")
+    //         .body(Body::Empty)
+    //         .expect("failed to build request")
+    //         .with_path_parameters(HashMap::from([(
+    //             "country".to_string(),
+    //             "United%20States".to_string(),
+    //         )]))
+    //         .with_query_string_parameters(HashMap::from([(
+    //             "region".to_string(),
+    //             "Texas".to_string(),
+    //         )]))
+    //         .with_query_string_parameters(HashMap::from([(
+    //             "name".to_string(),
+    //             "Austin".to_string(),
+    //         )]))
+    //         .with_request_context(lambda_http::request::RequestContext::ApiGatewayV2(
+    //             lambda_http::aws_lambda_events::apigw::ApiGatewayV2httpRequestContext::default(),
+    //         ));
+    //     let r = function_handler(event).await.unwrap();
+    //     dbg!(r);
+    // }
 }


### PR DESCRIPTION
Ensures the path parameters and query strings are URL decoded before being read.

Drive-by:
- Updates the REST collection.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
