### PR TITLE
Fix cities entrypoint

### DIFF
--- a/entity/src/entities/city.rs
+++ b/entity/src/entities/city.rs
@@ -10,15 +10,15 @@ pub struct Model {
     pub city_id: Uuid,
     #[sea_orm(primary_key, auto_increment = false)]
     pub country: String,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub state: String,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub name: String,
     #[sea_orm(column_type = "Double", nullable)]
     pub latitude: Option<f64>,
     #[sea_orm(column_type = "Double", nullable)]
     pub longitude: Option<f64>,
-    #[sea_orm(primary_key, auto_increment = false)]
-    pub name: String,
     pub region: Option<String>,
-    #[sea_orm(primary_key, auto_increment = false)]
-    pub state: String,
     pub state_abbrev: Option<String>,
     pub speed_limit: Option<i32>,
     pub created_at: TimeDateTimeWithTimeZone,

--- a/lambdas/requests.rest
+++ b/lambdas/requests.rest
@@ -1,6 +1,6 @@
 @host=https://api.peopleforbikes.xyz
-# Walla Walla, WA.
-@city_id=1c8f4f93-3537-4f31-ba0c-e165ebf67b74
+# Austin, TX, USA.
+@city_id=ef8384d5-b96f-439d-a83b-bc801735ddc6
 @bna_id=1a759b85-cd87-4bb1-9efa-5789e38e9982
 @country=United States
 @region=Texas

--- a/lambdas/src/cities/get-cities.rs
+++ b/lambdas/src/cities/get-cities.rs
@@ -67,3 +67,28 @@ async fn main() -> Result<(), Error> {
         e
     })
 }
+
+#[cfg(test)]
+mod tests {
+    // use super::*;
+    // use lambda_http::{http, RequestExt};
+    // use std::collections::HashMap;
+
+    // #[tokio::test]
+    // async fn test_handler_opportunity() {
+    //     let event = http::Request::builder()
+    //         .header(http::header::CONTENT_TYPE, "application/json")
+    //         .body(Body::Empty)
+    //         .expect("failed to build request")
+    //         .with_path_parameters(HashMap::from([
+    //             ("country".to_string(), "United%20States".to_string()),
+    //             ("region".to_string(), "Texas".to_string()),
+    //             ("name".to_string(), "Austin".to_string()),
+    //         ]))
+    //         .with_request_context(lambda_http::request::RequestContext::ApiGatewayV2(
+    //             lambda_http::aws_lambda_events::apigw::ApiGatewayV2httpRequestContext::default(),
+    //         ));
+    //     let r = function_handler(event).await.unwrap();
+    //     dbg!(r);
+    // }
+}

--- a/lambdas/tests/smoke/public-readonly.hurl
+++ b/lambdas/tests/smoke/public-readonly.hurl
@@ -15,7 +15,8 @@ GET {{host}}/cities
 HTTP 200
 
 # Query a specific city.
-GET {{host}}/cities/{{city_id}}
+GET {{host}}/cities/{{country}}/{{region}}/{{name}}
+# GET {{host}}/cities/United%20States/Texas/Austin
 HTTP 200
 
 # Query all the BNAs of a specific city.

--- a/lambdas/tests/staging.vars
+++ b/lambdas/tests/staging.vars
@@ -1,5 +1,7 @@
 host=https://api.peopleforbikes.xyz
 bna_id=1a759b85-cd87-4bb1-9efa-5789e38e9982
-# Albuquerque, NM, USA.
-city_id=371117d3-53d2-4e0b-982f-9fe28e641297
 max_page_size=100
+country=United%20States
+region=Texas
+name=Austin
+city_id=ef8384d5-b96f-439d-a83b-bc801735ddc6

--- a/migration/src/m20220101_000001_main.rs
+++ b/migration/src/m20220101_000001_main.rs
@@ -77,11 +77,11 @@ impl MigrationTrait for Migration {
                     .if_not_exists()
                     .col(ColumnDef::new(City::CityId).uuid().unique_key().not_null())
                     .col(ColumnDef::new(City::Country).string().not_null())
+                    .col(ColumnDef::new(City::State).string().not_null())
+                    .col(ColumnDef::new(City::Name).string().not_null())
                     .col(ColumnDef::new(City::Latitude).double())
                     .col(ColumnDef::new(City::Longitude).double())
-                    .col(ColumnDef::new(City::Name).string().not_null())
                     .col(ColumnDef::new(City::Region).string())
-                    .col(ColumnDef::new(City::State).string().not_null())
                     .col(ColumnDef::new(City::StateAbbrev).string())
                     .col(ColumnDef::new(City::SpeedLimit).integer())
                     .col(


### PR DESCRIPTION
Fixes the `/cities` entrypoint

The order in which the fields are defined in the migration influences
the composite primary key.

The migration and smoke tests were updated accordingly.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
