### PR TITLE
Fix post-cities

### DIFF
--- a/lambdas/requests.rest
+++ b/lambdas/requests.rest
@@ -113,7 +113,7 @@ Authorization: Bearer {{cognito_access}}
 
 {
   "city": "santa rosa",
-  "country": "usa",
+  "country": "United States",
   "fips_code": "3570670",
   "region": "new mexico"
 }
@@ -131,7 +131,7 @@ Authorization: Bearer {{cognito_access}}
 
 {
   "city": "santa rosa",
-  "country": "usa",
+  "country": "United States",
   "email": "jane.dpe@orgllc.com",
   "fips_code": "3570670",
   "first_name": "Jane",


### PR DESCRIPTION
Fix the POST /cities endpoint by generating a new UUID when creating a
new city.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
