### PR TITLE
Update seeder

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,28 +1,27 @@
-version: "3"
 services:
   postgres:
     image: postgres:15.2
     environment:
-        POSTGRES_PASSWORD: postgres
-        POSTGRES_USER: postgres
-        POSTGRESQL_USERNAME: bna
-        POSTGRESQL_PASSWORD: bna
-        POSTGRESQL_DATABASE: bna
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+      POSTGRESQL_USERNAME: bna
+      POSTGRESQL_PASSWORD: bna
+      POSTGRESQL_DATABASE: bna
     ports:
       - 5432:5432
     volumes:
-        - postgres:/var/lib/postgresql/data
+      - postgres:/var/lib/postgresql/data
 
   pgadmin:
     image: dpage/pgadmin4:7.6
     environment:
-        PGADMIN_DEFAULT_EMAIL: admin@pgadmin.com
-        PGADMIN_DEFAULT_PASSWORD: admin
-        PGADMIN_LISTEN_PORT: 80
+      PGADMIN_DEFAULT_EMAIL: admin@pgadmin.com
+      PGADMIN_DEFAULT_PASSWORD: admin
+      PGADMIN_LISTEN_PORT: 80
     ports:
       - 8484:80
     volumes:
-        - ./docker/servers.json:/pgadmin4/servers.json
+      - ./docker/servers.json:/pgadmin4/servers.json
 
 volumes:
   postgres:

--- a/justfile
+++ b/justfile
@@ -66,3 +66,13 @@ dbml-sql:
 # Generate the SVG diagram from dbml.
 dbml-svg:
   npx -y --package=@softwaretechnik/dbml-renderer dbml-renderer -i docs/database.dbml -o docs/database.svg
+
+# Spins up Docker Compose.
+compose-up:
+  docker compose up -d
+
+# Tears down Docker Compose.
+compose-down:
+  docker compose down
+  docker compose rm -sfv
+  docker volume rm -f bna-api_postgres


### PR DESCRIPTION
Updates the seeder to import the historical results.

Drive-by:
- Removes obsolote compose keys.
- Adds Just tasks to manage compose.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
