### PR TITLE
Fix POST /cities/submissions

### DIFF
--- a/lambdas/src/cities/post-cities-submissions.rs
+++ b/lambdas/src/cities/post-cities-submissions.rs
@@ -1,12 +1,12 @@
 use dotenv::dotenv;
-use effortless::api::parse_request_body;
+use effortless::api::{invalid_body, parse_request_body};
 use entity::wrappers::submission::SubmissionPost;
 use lambda_http::{
     http::{header, StatusCode},
     run, service_fn, Body, Error, Request, Response,
 };
-use lambdas::database_connect;
-use sea_orm::{ActiveModelTrait, IntoActiveModel};
+use lambdas::{database_connect, db::find_country};
+use sea_orm::{ActiveModelTrait, ActiveValue, IntoActiveModel};
 use serde_json::json;
 use tracing::info;
 
@@ -18,19 +18,38 @@ async fn function_handler(event: Request) -> Result<Response<Body>, Error> {
         Ok(value) => value,
         Err(e) => return Ok(e.into()),
     };
+    let country = wrapper.country.clone();
 
     // Turn the model wrapper into an active model.
-    let active_submission = wrapper.into_active_model();
+    let mut active_submission = wrapper.into_active_model();
 
     // Get the database connection.
     let db = database_connect(Some("DATABASE_URL_SECRET_ID")).await?;
+
+    // Add the status.
+    active_submission.status = ActiveValue::Set("Pending".to_string());
+
+    // Ensure the country is a valid one.
+    let country_found = find_country(&db, &country).await?;
+    dbg!(country_found);
+    if !find_country(&db, &country).await? {
+        return Ok(invalid_body(
+            &event,
+            format!("the country `{country}` is not in the list of countries supported by the BNA")
+                .as_str(),
+        )
+        .into());
+    }
 
     // And insert a new entry.
     info!(
         "inserting Submission into database: {:?}",
         active_submission
     );
-    let submission = active_submission.insert(&db).await?;
+    let submission = match active_submission.insert(&db).await {
+        Ok(m) => m,
+        Err(e) => return Ok(invalid_body(&event, e.to_string().as_str()).into()),
+    };
     let response = Response::builder()
         .status(StatusCode::CREATED)
         .header(header::CONTENT_TYPE, "application/json")
@@ -53,4 +72,39 @@ async fn main() -> Result<(), Error> {
         info!("{e}");
         e
     })
+}
+
+#[cfg(test)]
+mod tests {
+
+    //     use super::*;
+    //     use aws_lambda_events::http;
+    //     use lambda_http::RequestExt;
+
+    //     #[tokio::test]
+    //     async fn test_handler() {
+    //         let event = http::Request::builder()
+    //             .header(http::header::CONTENT_TYPE, "application/json")
+    //             .body(Body::Text(
+    //                 r#"{
+    //   "city": "santa rosa",
+    //   "country": "United States",
+    //   "email": "jane.dpe@orgllc.com",
+    //   "fips_code": "3570670",
+    //   "first_name": "Jane",
+    //   "last_name": "Doe",
+    //   "organization": "Organization LLC",
+    //   "region": "new mexico",
+    //   "occupation": "CTO",
+    //   "consent": true
+    // }"#
+    //                 .to_string(),
+    //             ))
+    //             .expect("failed to build request")
+    //             .with_request_context(lambda_http::request::RequestContext::ApiGatewayV2(
+    //                 lambda_http::aws_lambda_events::apigw::ApiGatewayV2httpRequestContext::default(),
+    //             ));
+    //         let r = function_handler(event).await.unwrap();
+    //         dbg!(r);
+    //     }
 }

--- a/lambdas/src/cities/post-cities.rs
+++ b/lambdas/src/cities/post-cities.rs
@@ -3,12 +3,11 @@ use effortless::{
     api::{invalid_body, parse_request_body},
     response::make_json_created_response,
 };
-use entity::{country, prelude::*, state_region_crosswalk, wrappers::city::CityPost};
+use entity::{prelude::*, state_region_crosswalk, wrappers::city::CityPost};
 use lambda_http::{run, service_fn, Body, Error, Request, Response};
-use lambdas::database_connect;
+use lambdas::{database_connect, db::find_country};
 use sea_orm::{
-    ActiveModelTrait, ActiveValue, ColumnTrait, DatabaseConnection, DbErr, EntityTrait,
-    IntoActiveModel, QueryFilter,
+    ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter,
 };
 use serde_json::json;
 use tracing::info;
@@ -87,14 +86,6 @@ async fn function_handler(event: Request) -> Result<Response<Body>, Error> {
     let response = make_json_created_response(json!(city).to_string())
         .expect("unable to build http::Response");
     Ok(response)
-}
-
-async fn find_country(db: &DatabaseConnection, country: &str) -> Result<bool, DbErr> {
-    Ok(Country::find()
-        .filter(country::Column::Name.eq(country))
-        .one(db)
-        .await?
-        .is_none())
 }
 
 // async fn find_us_state_abrev(

--- a/lambdas/src/db.rs
+++ b/lambdas/src/db.rs
@@ -1,0 +1,10 @@
+use entity::{country, prelude::*};
+use sea_orm::{ColumnTrait, DatabaseConnection, DbErr, EntityTrait, QueryFilter};
+
+pub async fn find_country(db: &DatabaseConnection, country: &str) -> Result<bool, DbErr> {
+    Ok(Country::find()
+        .filter(country::Column::Name.eq(country))
+        .one(db)
+        .await?
+        .is_some())
+}

--- a/lambdas/src/lib.rs
+++ b/lambdas/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod bnas;
 pub mod cities;
+pub mod db;
 pub mod link_header;
 
 use bnacore::aws::get_aws_secrets_value;

--- a/lambdas/tests/smoke/public-readonly.hurl
+++ b/lambdas/tests/smoke/public-readonly.hurl
@@ -28,14 +28,14 @@ content-type: application/json
 
 {
   "city": "santa rosa",
-  "country": "usa",
+  "country": "United States",
   "email": "jane.dpe@orgllc.com",
   "fips_code": "3570670",
   "first_name": "Jane",
   "last_name": "Doe",
   "organization": "Organization LLC",
   "region": "new mexico",
-  "title": "CTO",
+  "occupation": "CTO",
   "consent": true
 }
 HTTP 200


### PR DESCRIPTION
Fixes the POST `/cities/submissions` endpoint and the related
integration tests.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
