### PR TITLE
Fix APIErrorSource case

### DIFF
--- a/effortless/src/error.rs
+++ b/effortless/src/error.rs
@@ -16,6 +16,7 @@ use serde_with::skip_serializing_none;
 ///   - header: a string indicating the name of a single request header which caused the
 ///     error.
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "snake_case")]
 pub enum APIErrorSource {
     Pointer(String),
     Parameter(String),


### PR DESCRIPTION
Ensures the APIErrorSouce Enum gets serialized in snake_case format.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
