### PR TITLE
Populate pipeline tables

### DIFF
--- a/entity/src/wrappers/mod.rs
+++ b/entity/src/wrappers/mod.rs
@@ -23,14 +23,29 @@ impl FromStr for ApprovalStatus {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum BrokenspokeStep {
-    SqsMessage,
-    Setup,
-    Analysis,
-    Cleanup,
+pub enum BNAPipelineStatus {
+    Pending,
+    Processing,
+    Completed,
 }
 
-impl FromStr for BrokenspokeStep {
+impl FromStr for BNAPipelineStatus {
+    type Err = serde_plain::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_plain::from_str::<Self>(s)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BNAPipelineStep {
+    Analysis,
+    Cleanup,
+    Setup,
+    Save,
+}
+
+impl FromStr for BNAPipelineStep {
     type Err = serde_plain::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {

--- a/migration/src/m20240202_004130_brokenspoke_analyzer_pipeline.rs
+++ b/migration/src/m20240202_004130_brokenspoke_analyzer_pipeline.rs
@@ -22,6 +22,14 @@ impl MigrationTrait for Migration {
                     .to_owned(),
             )
             .await?;
+        let insert_statuses = Query::insert()
+            .into_table(BNAPipelineStatus::Table)
+            .columns([BNAPipelineStatus::Status])
+            .values_panic(["Completed".into()])
+            .values_panic(["Pending".into()])
+            .values_panic(["Processing".into()])
+            .to_owned();
+        manager.exec_stmt(insert_statuses).await?;
 
         // Create the Brokenspoke Step lookup table.
         manager
@@ -33,6 +41,15 @@ impl MigrationTrait for Migration {
                     .to_owned(),
             )
             .await?;
+        let insert_statuses = Query::insert()
+            .into_table(BNAPipelineStep::Table)
+            .columns([BNAPipelineStep::Step])
+            .values_panic(["Analysis".into()])
+            .values_panic(["Cleanup".into()])
+            .values_panic(["Save".into()])
+            .values_panic(["Setup ".into()])
+            .to_owned();
+        manager.exec_stmt(insert_statuses).await?;
 
         // Create the Fargate Price table.
         manager


### PR DESCRIPTION
Populates the BNA pipeline tables with the migration.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
