### PR TITLE
Fix BNA Pipeline Step migration

### DIFF
--- a/migration/src/m20240202_004130_brokenspoke_analyzer_pipeline.rs
+++ b/migration/src/m20240202_004130_brokenspoke_analyzer_pipeline.rs
@@ -47,7 +47,7 @@ impl MigrationTrait for Migration {
             .values_panic(["Analysis".into()])
             .values_panic(["Cleanup".into()])
             .values_panic(["Save".into()])
-            .values_panic(["Setup ".into()])
+            .values_panic(["Setup".into()])
             .to_owned();
         manager.exec_stmt(insert_statuses).await?;
 


### PR DESCRIPTION
Removes teh extra space add the end of the 'Setup' step.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
