### PR TITLE
Fix BNA pipeline status

### DIFF
--- a/bnaclient/src/lib.rs
+++ b/bnaclient/src/lib.rs
@@ -485,21 +485,21 @@ pub mod types {
         }
     }
 
-    ///
+    ///BNA Pipeline status
     ///
     /// <details><summary>JSON schema</summary>
     ///
     /// ```json
     ///{
-    ///  "description": "",
+    ///  "description": "BNA Pipeline status",
     ///  "examples": [
     ///    "Pending"
     ///  ],
     ///  "type": "string",
     ///  "enum": [
-    ///    "Complete",
+    ///    "Completed",
     ///    "Pending",
-    ///    "InProgress"
+    ///    "Processing"
     ///  ]
     ///}
     /// ```
@@ -517,9 +517,9 @@ pub mod types {
         PartialOrd,
     )]
     pub enum AnalysisStatus {
-        Complete,
+        Completed,
         Pending,
-        InProgress,
+        Processing,
     }
 
     impl From<&AnalysisStatus> for AnalysisStatus {
@@ -531,9 +531,9 @@ pub mod types {
     impl ::std::fmt::Display for AnalysisStatus {
         fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
             match *self {
-                Self::Complete => write!(f, "Complete"),
+                Self::Completed => write!(f, "Completed"),
                 Self::Pending => write!(f, "Pending"),
-                Self::InProgress => write!(f, "InProgress"),
+                Self::Processing => write!(f, "Processing"),
             }
         }
     }
@@ -542,9 +542,9 @@ pub mod types {
         type Err = self::error::ConversionError;
         fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
             match value {
-                "Complete" => Ok(Self::Complete),
+                "Completed" => Ok(Self::Completed),
                 "Pending" => Ok(Self::Pending),
-                "InProgress" => Ok(Self::InProgress),
+                "Processing" => Ok(Self::Processing),
                 _ => Err("invalid value".into()),
             }
         }

--- a/lambdas/requests.rest
+++ b/lambdas/requests.rest
@@ -165,11 +165,11 @@ Authorization: Bearer {{cognito_access}}
 }
 
 ### Query the BNA analysis performed by the Brokenspoke-analyzer pipeline.
-GET {{host}}/ratings/analysis
+GET {{host}}/ratings/analyses
 Authorization: Bearer {{cognito_access}}
 
 ### Query a specific BNA analysis performed by the Brokenspoke-analyzer pipeline.
-GET {{host}}/ratings/analysis/{{state_machine_id}}
+GET {{host}}/ratings/analyses/{{state_machine_id}}
 Authorization: Bearer {{cognito_access}}
 
 ### Update an existing BNA analysis performed by the Brokenspoke-analyzer pipeline.
@@ -179,6 +179,22 @@ Authorization: Bearer {{cognito_access}}
 
 {
   "neon_branch_id": "br-aged-salad-637688"
+}
+
+
+
+###
+#
+PATCH {{host}}/ratings/analyses/c86473dd-53b5-4abd-be0d-c25ed6b5f029
+content-type: application/json
+Authorization: Bearer {{cognito_access}}
+
+{
+  "cost": 10.345,
+  "results_posted": true,
+  "start_time": "2024-12-09T18:02:22.607245Z",
+  "status": "Completed",
+  "step": "Setup"
 }
 
 ### Create a new BNA .

--- a/lambdas/src/core/resource/ratings/endpoint.rs
+++ b/lambdas/src/core/resource/ratings/endpoint.rs
@@ -91,7 +91,6 @@ async fn get_ratings_analysis(
         .map(Json)
 }
 
-#[debug_handler]
 async fn post_ratings_analysis(
     Json(bna_pipeline): Json<BNAPipelinePost>,
 ) -> Result<(StatusCode, Json<Value>), ExecutionError> {
@@ -104,12 +103,17 @@ async fn post_ratings_analysis(
         .map(|v| (StatusCode::CREATED, Json(v)))
 }
 
+#[debug_handler]
 async fn patch_ratings_analysis(
     Path(analysis_id): Path<Uuid>,
     Json(bna_pipeline): Json<BNAPipelinePatch>,
 ) -> Result<Json<Value>, ExecutionError> {
     patch_ratings_analysis_adaptor(bna_pipeline, analysis_id)
         .await
+        .map_err(|e| {
+            debug!("{e}");
+            e
+        })
         .map(Json)
 }
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -570,10 +570,10 @@ components:
     analysis_status:
       type: string
       enum:
-        - Complete
+        - Completed
         - Pending
-        - InProgress
-      description: ""
+        - Processing
+      description: "BNA Pipeline status"
       example: "Pending"
     api_gateway_id:
       type: string


### PR DESCRIPTION
Fix the list of defined statuses for the BNA pipeline.

The `bnaclient` was regenerated.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
