### PR TITLE
Fix ApiErrors struct

### DIFF
--- a/bnaclient/src/lib.rs
+++ b/bnaclient/src/lib.rs
@@ -229,6 +229,47 @@ pub mod types {
         }
     }
 
+    ///Error objects MUST be returned as an array keyed by errors in the top
+    /// level of a JSON:API document.
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "description": "Error objects MUST be returned as an array keyed by
+    /// errors in the top level of a\nJSON:API document.",
+    ///  "type": "object",
+    ///  "required": [
+    ///    "errors"
+    ///  ],
+    ///  "properties": {
+    ///    "errors": {
+    ///      "type": "array",
+    ///      "items": {
+    ///        "$ref": "#/components/schemas/APIError"
+    ///      }
+    ///    }
+    ///  }
+    ///}
+    /// ```
+    /// </details>
+    #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+    pub struct ApiErrors {
+        pub errors: ::std::vec::Vec<ApiError>,
+    }
+
+    impl ::std::convert::From<&ApiErrors> for ApiErrors {
+        fn from(value: &ApiErrors) -> Self {
+            value.clone()
+        }
+    }
+
+    impl ApiErrors {
+        pub fn builder() -> builder::ApiErrors {
+            Default::default()
+        }
+    }
+
     ///BnaPipeline
     ///
     /// <details><summary>JSON schema</summary>
@@ -1768,416 +1809,6 @@ pub mod types {
         }
     }
 
-    ///Error objects MUST be returned as an array keyed by errors in the top
-    /// level of a JSON:API document.
-    ///
-    /// <details><summary>JSON schema</summary>
-    ///
-    /// ```json
-    ///{
-    ///  "description": "Error objects MUST be returned as an array keyed by
-    /// errors in the top level of a\nJSON:API document.",
-    ///  "type": "object",
-    ///  "required": [
-    ///    "errors"
-    ///  ],
-    ///  "properties": {
-    ///    "errors": {
-    ///      "type": "array",
-    ///      "items": {
-    ///        "$ref": "#/components/schemas/APIError"
-    ///      }
-    ///    }
-    ///  }
-    ///}
-    /// ```
-    /// </details>
-    #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    pub struct GetCitiesSubmissionResponse {
-        pub errors: ::std::vec::Vec<ApiError>,
-    }
-
-    impl ::std::convert::From<&GetCitiesSubmissionResponse> for GetCitiesSubmissionResponse {
-        fn from(value: &GetCitiesSubmissionResponse) -> Self {
-            value.clone()
-        }
-    }
-
-    impl GetCitiesSubmissionResponse {
-        pub fn builder() -> builder::GetCitiesSubmissionResponse {
-            Default::default()
-        }
-    }
-
-    ///Error objects MUST be returned as an array keyed by errors in the top
-    /// level of a JSON:API document.
-    ///
-    /// <details><summary>JSON schema</summary>
-    ///
-    /// ```json
-    ///{
-    ///  "description": "Error objects MUST be returned as an array keyed by
-    /// errors in the top level of a\nJSON:API document.",
-    ///  "type": "object",
-    ///  "required": [
-    ///    "errors"
-    ///  ],
-    ///  "properties": {
-    ///    "errors": {
-    ///      "type": "array",
-    ///      "items": {
-    ///        "$ref": "#/components/schemas/APIError"
-    ///      }
-    ///    }
-    ///  }
-    ///}
-    /// ```
-    /// </details>
-    #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    pub struct GetCitiesSubmissionsResponse {
-        pub errors: ::std::vec::Vec<ApiError>,
-    }
-
-    impl ::std::convert::From<&GetCitiesSubmissionsResponse> for GetCitiesSubmissionsResponse {
-        fn from(value: &GetCitiesSubmissionsResponse) -> Self {
-            value.clone()
-        }
-    }
-
-    impl GetCitiesSubmissionsResponse {
-        pub fn builder() -> builder::GetCitiesSubmissionsResponse {
-            Default::default()
-        }
-    }
-
-    ///Error objects MUST be returned as an array keyed by errors in the top
-    /// level of a JSON:API document.
-    ///
-    /// <details><summary>JSON schema</summary>
-    ///
-    /// ```json
-    ///{
-    ///  "description": "Error objects MUST be returned as an array keyed by
-    /// errors in the top level of a\nJSON:API document.",
-    ///  "type": "object",
-    ///  "required": [
-    ///    "errors"
-    ///  ],
-    ///  "properties": {
-    ///    "errors": {
-    ///      "type": "array",
-    ///      "items": {
-    ///        "$ref": "#/components/schemas/APIError"
-    ///      }
-    ///    }
-    ///  }
-    ///}
-    /// ```
-    /// </details>
-    #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    pub struct GetCityCensusesResponse {
-        pub errors: ::std::vec::Vec<ApiError>,
-    }
-
-    impl ::std::convert::From<&GetCityCensusesResponse> for GetCityCensusesResponse {
-        fn from(value: &GetCityCensusesResponse) -> Self {
-            value.clone()
-        }
-    }
-
-    impl GetCityCensusesResponse {
-        pub fn builder() -> builder::GetCityCensusesResponse {
-            Default::default()
-        }
-    }
-
-    ///Error objects MUST be returned as an array keyed by errors in the top
-    /// level of a JSON:API document.
-    ///
-    /// <details><summary>JSON schema</summary>
-    ///
-    /// ```json
-    ///{
-    ///  "description": "Error objects MUST be returned as an array keyed by
-    /// errors in the top level of a\nJSON:API document.",
-    ///  "type": "object",
-    ///  "required": [
-    ///    "errors"
-    ///  ],
-    ///  "properties": {
-    ///    "errors": {
-    ///      "type": "array",
-    ///      "items": {
-    ///        "$ref": "#/components/schemas/APIError"
-    ///      }
-    ///    }
-    ///  }
-    ///}
-    /// ```
-    /// </details>
-    #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    pub struct GetCityRatingsResponse {
-        pub errors: ::std::vec::Vec<ApiError>,
-    }
-
-    impl ::std::convert::From<&GetCityRatingsResponse> for GetCityRatingsResponse {
-        fn from(value: &GetCityRatingsResponse) -> Self {
-            value.clone()
-        }
-    }
-
-    impl GetCityRatingsResponse {
-        pub fn builder() -> builder::GetCityRatingsResponse {
-            Default::default()
-        }
-    }
-
-    ///Error objects MUST be returned as an array keyed by errors in the top
-    /// level of a JSON:API document.
-    ///
-    /// <details><summary>JSON schema</summary>
-    ///
-    /// ```json
-    ///{
-    ///  "description": "Error objects MUST be returned as an array keyed by
-    /// errors in the top level of a\nJSON:API document.",
-    ///  "type": "object",
-    ///  "required": [
-    ///    "errors"
-    ///  ],
-    ///  "properties": {
-    ///    "errors": {
-    ///      "type": "array",
-    ///      "items": {
-    ///        "$ref": "#/components/schemas/APIError"
-    ///      }
-    ///    }
-    ///  }
-    ///}
-    /// ```
-    /// </details>
-    #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    pub struct GetCityResponse {
-        pub errors: ::std::vec::Vec<ApiError>,
-    }
-
-    impl ::std::convert::From<&GetCityResponse> for GetCityResponse {
-        fn from(value: &GetCityResponse) -> Self {
-            value.clone()
-        }
-    }
-
-    impl GetCityResponse {
-        pub fn builder() -> builder::GetCityResponse {
-            Default::default()
-        }
-    }
-
-    ///Error objects MUST be returned as an array keyed by errors in the top
-    /// level of a JSON:API document.
-    ///
-    /// <details><summary>JSON schema</summary>
-    ///
-    /// ```json
-    ///{
-    ///  "description": "Error objects MUST be returned as an array keyed by
-    /// errors in the top level of a\nJSON:API document.",
-    ///  "type": "object",
-    ///  "required": [
-    ///    "errors"
-    ///  ],
-    ///  "properties": {
-    ///    "errors": {
-    ///      "type": "array",
-    ///      "items": {
-    ///        "$ref": "#/components/schemas/APIError"
-    ///      }
-    ///    }
-    ///  }
-    ///}
-    /// ```
-    /// </details>
-    #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    pub struct GetPipelinesBnaResponse {
-        pub errors: ::std::vec::Vec<ApiError>,
-    }
-
-    impl ::std::convert::From<&GetPipelinesBnaResponse> for GetPipelinesBnaResponse {
-        fn from(value: &GetPipelinesBnaResponse) -> Self {
-            value.clone()
-        }
-    }
-
-    impl GetPipelinesBnaResponse {
-        pub fn builder() -> builder::GetPipelinesBnaResponse {
-            Default::default()
-        }
-    }
-
-    ///Error objects MUST be returned as an array keyed by errors in the top
-    /// level of a JSON:API document.
-    ///
-    /// <details><summary>JSON schema</summary>
-    ///
-    /// ```json
-    ///{
-    ///  "description": "Error objects MUST be returned as an array keyed by
-    /// errors in the top level of a\nJSON:API document.",
-    ///  "type": "object",
-    ///  "required": [
-    ///    "errors"
-    ///  ],
-    ///  "properties": {
-    ///    "errors": {
-    ///      "type": "array",
-    ///      "items": {
-    ///        "$ref": "#/components/schemas/APIError"
-    ///      }
-    ///    }
-    ///  }
-    ///}
-    /// ```
-    /// </details>
-    #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    pub struct GetPipelinesBnasResponse {
-        pub errors: ::std::vec::Vec<ApiError>,
-    }
-
-    impl ::std::convert::From<&GetPipelinesBnasResponse> for GetPipelinesBnasResponse {
-        fn from(value: &GetPipelinesBnasResponse) -> Self {
-            value.clone()
-        }
-    }
-
-    impl GetPipelinesBnasResponse {
-        pub fn builder() -> builder::GetPipelinesBnasResponse {
-            Default::default()
-        }
-    }
-
-    ///Error objects MUST be returned as an array keyed by errors in the top
-    /// level of a JSON:API document.
-    ///
-    /// <details><summary>JSON schema</summary>
-    ///
-    /// ```json
-    ///{
-    ///  "description": "Error objects MUST be returned as an array keyed by
-    /// errors in the top level of a\nJSON:API document.",
-    ///  "type": "object",
-    ///  "required": [
-    ///    "errors"
-    ///  ],
-    ///  "properties": {
-    ///    "errors": {
-    ///      "type": "array",
-    ///      "items": {
-    ///        "$ref": "#/components/schemas/APIError"
-    ///      }
-    ///    }
-    ///  }
-    ///}
-    /// ```
-    /// </details>
-    #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    pub struct GetPriceFargateResponse {
-        pub errors: ::std::vec::Vec<ApiError>,
-    }
-
-    impl ::std::convert::From<&GetPriceFargateResponse> for GetPriceFargateResponse {
-        fn from(value: &GetPriceFargateResponse) -> Self {
-            value.clone()
-        }
-    }
-
-    impl GetPriceFargateResponse {
-        pub fn builder() -> builder::GetPriceFargateResponse {
-            Default::default()
-        }
-    }
-
-    ///Error objects MUST be returned as an array keyed by errors in the top
-    /// level of a JSON:API document.
-    ///
-    /// <details><summary>JSON schema</summary>
-    ///
-    /// ```json
-    ///{
-    ///  "description": "Error objects MUST be returned as an array keyed by
-    /// errors in the top level of a\nJSON:API document.",
-    ///  "type": "object",
-    ///  "required": [
-    ///    "errors"
-    ///  ],
-    ///  "properties": {
-    ///    "errors": {
-    ///      "type": "array",
-    ///      "items": {
-    ///        "$ref": "#/components/schemas/APIError"
-    ///      }
-    ///    }
-    ///  }
-    ///}
-    /// ```
-    /// </details>
-    #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    pub struct GetRatingResponse {
-        pub errors: ::std::vec::Vec<ApiError>,
-    }
-
-    impl ::std::convert::From<&GetRatingResponse> for GetRatingResponse {
-        fn from(value: &GetRatingResponse) -> Self {
-            value.clone()
-        }
-    }
-
-    impl GetRatingResponse {
-        pub fn builder() -> builder::GetRatingResponse {
-            Default::default()
-        }
-    }
-
-    ///Error objects MUST be returned as an array keyed by errors in the top
-    /// level of a JSON:API document.
-    ///
-    /// <details><summary>JSON schema</summary>
-    ///
-    /// ```json
-    ///{
-    ///  "description": "Error objects MUST be returned as an array keyed by
-    /// errors in the top level of a\nJSON:API document.",
-    ///  "type": "object",
-    ///  "required": [
-    ///    "errors"
-    ///  ],
-    ///  "properties": {
-    ///    "errors": {
-    ///      "type": "array",
-    ///      "items": {
-    ///        "$ref": "#/components/schemas/APIError"
-    ///      }
-    ///    }
-    ///  }
-    ///}
-    /// ```
-    /// </details>
-    #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    pub struct GetRatingsCityResponse {
-        pub errors: ::std::vec::Vec<ApiError>,
-    }
-
-    impl ::std::convert::From<&GetRatingsCityResponse> for GetRatingsCityResponse {
-        fn from(value: &GetRatingsCityResponse) -> Self {
-            value.clone()
-        }
-    }
-
-    impl GetRatingsCityResponse {
-        pub fn builder() -> builder::GetRatingsCityResponse {
-            Default::default()
-        }
-    }
-
     ///Infrastructure
     ///
     /// <details><summary>JSON schema</summary>
@@ -2355,88 +1986,6 @@ pub mod types {
         }
     }
 
-    ///Error objects MUST be returned as an array keyed by errors in the top
-    /// level of a JSON:API document.
-    ///
-    /// <details><summary>JSON schema</summary>
-    ///
-    /// ```json
-    ///{
-    ///  "description": "Error objects MUST be returned as an array keyed by
-    /// errors in the top level of a\nJSON:API document.",
-    ///  "type": "object",
-    ///  "required": [
-    ///    "errors"
-    ///  ],
-    ///  "properties": {
-    ///    "errors": {
-    ///      "type": "array",
-    ///      "items": {
-    ///        "$ref": "#/components/schemas/APIError"
-    ///      }
-    ///    }
-    ///  }
-    ///}
-    /// ```
-    /// </details>
-    #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    pub struct PatchCitiesSubmissionResponse {
-        pub errors: ::std::vec::Vec<ApiError>,
-    }
-
-    impl ::std::convert::From<&PatchCitiesSubmissionResponse> for PatchCitiesSubmissionResponse {
-        fn from(value: &PatchCitiesSubmissionResponse) -> Self {
-            value.clone()
-        }
-    }
-
-    impl PatchCitiesSubmissionResponse {
-        pub fn builder() -> builder::PatchCitiesSubmissionResponse {
-            Default::default()
-        }
-    }
-
-    ///Error objects MUST be returned as an array keyed by errors in the top
-    /// level of a JSON:API document.
-    ///
-    /// <details><summary>JSON schema</summary>
-    ///
-    /// ```json
-    ///{
-    ///  "description": "Error objects MUST be returned as an array keyed by
-    /// errors in the top level of a\nJSON:API document.",
-    ///  "type": "object",
-    ///  "required": [
-    ///    "errors"
-    ///  ],
-    ///  "properties": {
-    ///    "errors": {
-    ///      "type": "array",
-    ///      "items": {
-    ///        "$ref": "#/components/schemas/APIError"
-    ///      }
-    ///    }
-    ///  }
-    ///}
-    /// ```
-    /// </details>
-    #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    pub struct PatchPipelinesBnaResponse {
-        pub errors: ::std::vec::Vec<ApiError>,
-    }
-
-    impl ::std::convert::From<&PatchPipelinesBnaResponse> for PatchPipelinesBnaResponse {
-        fn from(value: &PatchPipelinesBnaResponse) -> Self {
-            value.clone()
-        }
-    }
-
-    impl PatchPipelinesBnaResponse {
-        pub fn builder() -> builder::PatchPipelinesBnaResponse {
-            Default::default()
-        }
-    }
-
     ///People
     ///
     /// <details><summary>JSON schema</summary>
@@ -2570,211 +2119,6 @@ pub mod types {
             value: ::std::string::String,
         ) -> ::std::result::Result<Self, self::error::ConversionError> {
             value.parse()
-        }
-    }
-
-    ///Error objects MUST be returned as an array keyed by errors in the top
-    /// level of a JSON:API document.
-    ///
-    /// <details><summary>JSON schema</summary>
-    ///
-    /// ```json
-    ///{
-    ///  "description": "Error objects MUST be returned as an array keyed by
-    /// errors in the top level of a\nJSON:API document.",
-    ///  "type": "object",
-    ///  "required": [
-    ///    "errors"
-    ///  ],
-    ///  "properties": {
-    ///    "errors": {
-    ///      "type": "array",
-    ///      "items": {
-    ///        "$ref": "#/components/schemas/APIError"
-    ///      }
-    ///    }
-    ///  }
-    ///}
-    /// ```
-    /// </details>
-    #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    pub struct PostCitiesSubmissionResponse {
-        pub errors: ::std::vec::Vec<ApiError>,
-    }
-
-    impl ::std::convert::From<&PostCitiesSubmissionResponse> for PostCitiesSubmissionResponse {
-        fn from(value: &PostCitiesSubmissionResponse) -> Self {
-            value.clone()
-        }
-    }
-
-    impl PostCitiesSubmissionResponse {
-        pub fn builder() -> builder::PostCitiesSubmissionResponse {
-            Default::default()
-        }
-    }
-
-    ///Error objects MUST be returned as an array keyed by errors in the top
-    /// level of a JSON:API document.
-    ///
-    /// <details><summary>JSON schema</summary>
-    ///
-    /// ```json
-    ///{
-    ///  "description": "Error objects MUST be returned as an array keyed by
-    /// errors in the top level of a\nJSON:API document.",
-    ///  "type": "object",
-    ///  "required": [
-    ///    "errors"
-    ///  ],
-    ///  "properties": {
-    ///    "errors": {
-    ///      "type": "array",
-    ///      "items": {
-    ///        "$ref": "#/components/schemas/APIError"
-    ///      }
-    ///    }
-    ///  }
-    ///}
-    /// ```
-    /// </details>
-    #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    pub struct PostCityCensusResponse {
-        pub errors: ::std::vec::Vec<ApiError>,
-    }
-
-    impl ::std::convert::From<&PostCityCensusResponse> for PostCityCensusResponse {
-        fn from(value: &PostCityCensusResponse) -> Self {
-            value.clone()
-        }
-    }
-
-    impl PostCityCensusResponse {
-        pub fn builder() -> builder::PostCityCensusResponse {
-            Default::default()
-        }
-    }
-
-    ///Error objects MUST be returned as an array keyed by errors in the top
-    /// level of a JSON:API document.
-    ///
-    /// <details><summary>JSON schema</summary>
-    ///
-    /// ```json
-    ///{
-    ///  "description": "Error objects MUST be returned as an array keyed by
-    /// errors in the top level of a\nJSON:API document.",
-    ///  "type": "object",
-    ///  "required": [
-    ///    "errors"
-    ///  ],
-    ///  "properties": {
-    ///    "errors": {
-    ///      "type": "array",
-    ///      "items": {
-    ///        "$ref": "#/components/schemas/APIError"
-    ///      }
-    ///    }
-    ///  }
-    ///}
-    /// ```
-    /// </details>
-    #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    pub struct PostCityResponse {
-        pub errors: ::std::vec::Vec<ApiError>,
-    }
-
-    impl ::std::convert::From<&PostCityResponse> for PostCityResponse {
-        fn from(value: &PostCityResponse) -> Self {
-            value.clone()
-        }
-    }
-
-    impl PostCityResponse {
-        pub fn builder() -> builder::PostCityResponse {
-            Default::default()
-        }
-    }
-
-    ///Error objects MUST be returned as an array keyed by errors in the top
-    /// level of a JSON:API document.
-    ///
-    /// <details><summary>JSON schema</summary>
-    ///
-    /// ```json
-    ///{
-    ///  "description": "Error objects MUST be returned as an array keyed by
-    /// errors in the top level of a\nJSON:API document.",
-    ///  "type": "object",
-    ///  "required": [
-    ///    "errors"
-    ///  ],
-    ///  "properties": {
-    ///    "errors": {
-    ///      "type": "array",
-    ///      "items": {
-    ///        "$ref": "#/components/schemas/APIError"
-    ///      }
-    ///    }
-    ///  }
-    ///}
-    /// ```
-    /// </details>
-    #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    pub struct PostPipelinesBnaResponse {
-        pub errors: ::std::vec::Vec<ApiError>,
-    }
-
-    impl ::std::convert::From<&PostPipelinesBnaResponse> for PostPipelinesBnaResponse {
-        fn from(value: &PostPipelinesBnaResponse) -> Self {
-            value.clone()
-        }
-    }
-
-    impl PostPipelinesBnaResponse {
-        pub fn builder() -> builder::PostPipelinesBnaResponse {
-            Default::default()
-        }
-    }
-
-    ///Error objects MUST be returned as an array keyed by errors in the top
-    /// level of a JSON:API document.
-    ///
-    /// <details><summary>JSON schema</summary>
-    ///
-    /// ```json
-    ///{
-    ///  "description": "Error objects MUST be returned as an array keyed by
-    /// errors in the top level of a\nJSON:API document.",
-    ///  "type": "object",
-    ///  "required": [
-    ///    "errors"
-    ///  ],
-    ///  "properties": {
-    ///    "errors": {
-    ///      "type": "array",
-    ///      "items": {
-    ///        "$ref": "#/components/schemas/APIError"
-    ///      }
-    ///    }
-    ///  }
-    ///}
-    /// ```
-    /// </details>
-    #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    pub struct PostRatingResponse {
-        pub errors: ::std::vec::Vec<ApiError>,
-    }
-
-    impl ::std::convert::From<&PostRatingResponse> for PostRatingResponse {
-        fn from(value: &PostRatingResponse) -> Self {
-            value.clone()
-        }
-    }
-
-    impl PostRatingResponse {
-        pub fn builder() -> builder::PostRatingResponse {
-            Default::default()
         }
     }
 
@@ -3907,6 +3251,51 @@ pub mod types {
                     source: Ok(value.source),
                     status: Ok(value.status),
                     title: Ok(value.title),
+                }
+            }
+        }
+
+        #[derive(Clone, Debug)]
+        pub struct ApiErrors {
+            errors: ::std::result::Result<::std::vec::Vec<super::ApiError>, ::std::string::String>,
+        }
+
+        impl ::std::default::Default for ApiErrors {
+            fn default() -> Self {
+                Self {
+                    errors: Err("no value supplied for errors".to_string()),
+                }
+            }
+        }
+
+        impl ApiErrors {
+            pub fn errors<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::vec::Vec<super::ApiError>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.errors = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for errors: {}", e));
+                self
+            }
+        }
+
+        impl ::std::convert::TryFrom<ApiErrors> for super::ApiErrors {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: ApiErrors,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    errors: value.errors?,
+                })
+            }
+        }
+
+        impl ::std::convert::From<super::ApiErrors> for ApiErrors {
+            fn from(value: super::ApiErrors) -> Self {
+                Self {
+                    errors: Ok(value.errors),
                 }
             }
         }
@@ -5328,456 +4717,6 @@ pub mod types {
         }
 
         #[derive(Clone, Debug)]
-        pub struct GetCitiesSubmissionResponse {
-            errors: ::std::result::Result<::std::vec::Vec<super::ApiError>, ::std::string::String>,
-        }
-
-        impl ::std::default::Default for GetCitiesSubmissionResponse {
-            fn default() -> Self {
-                Self {
-                    errors: Err("no value supplied for errors".to_string()),
-                }
-            }
-        }
-
-        impl GetCitiesSubmissionResponse {
-            pub fn errors<T>(mut self, value: T) -> Self
-            where
-                T: ::std::convert::TryInto<::std::vec::Vec<super::ApiError>>,
-                T::Error: ::std::fmt::Display,
-            {
-                self.errors = value
-                    .try_into()
-                    .map_err(|e| format!("error converting supplied value for errors: {}", e));
-                self
-            }
-        }
-
-        impl ::std::convert::TryFrom<GetCitiesSubmissionResponse> for super::GetCitiesSubmissionResponse {
-            type Error = super::error::ConversionError;
-            fn try_from(
-                value: GetCitiesSubmissionResponse,
-            ) -> ::std::result::Result<Self, super::error::ConversionError> {
-                Ok(Self {
-                    errors: value.errors?,
-                })
-            }
-        }
-
-        impl ::std::convert::From<super::GetCitiesSubmissionResponse> for GetCitiesSubmissionResponse {
-            fn from(value: super::GetCitiesSubmissionResponse) -> Self {
-                Self {
-                    errors: Ok(value.errors),
-                }
-            }
-        }
-
-        #[derive(Clone, Debug)]
-        pub struct GetCitiesSubmissionsResponse {
-            errors: ::std::result::Result<::std::vec::Vec<super::ApiError>, ::std::string::String>,
-        }
-
-        impl ::std::default::Default for GetCitiesSubmissionsResponse {
-            fn default() -> Self {
-                Self {
-                    errors: Err("no value supplied for errors".to_string()),
-                }
-            }
-        }
-
-        impl GetCitiesSubmissionsResponse {
-            pub fn errors<T>(mut self, value: T) -> Self
-            where
-                T: ::std::convert::TryInto<::std::vec::Vec<super::ApiError>>,
-                T::Error: ::std::fmt::Display,
-            {
-                self.errors = value
-                    .try_into()
-                    .map_err(|e| format!("error converting supplied value for errors: {}", e));
-                self
-            }
-        }
-
-        impl ::std::convert::TryFrom<GetCitiesSubmissionsResponse> for super::GetCitiesSubmissionsResponse {
-            type Error = super::error::ConversionError;
-            fn try_from(
-                value: GetCitiesSubmissionsResponse,
-            ) -> ::std::result::Result<Self, super::error::ConversionError> {
-                Ok(Self {
-                    errors: value.errors?,
-                })
-            }
-        }
-
-        impl ::std::convert::From<super::GetCitiesSubmissionsResponse> for GetCitiesSubmissionsResponse {
-            fn from(value: super::GetCitiesSubmissionsResponse) -> Self {
-                Self {
-                    errors: Ok(value.errors),
-                }
-            }
-        }
-
-        #[derive(Clone, Debug)]
-        pub struct GetCityCensusesResponse {
-            errors: ::std::result::Result<::std::vec::Vec<super::ApiError>, ::std::string::String>,
-        }
-
-        impl ::std::default::Default for GetCityCensusesResponse {
-            fn default() -> Self {
-                Self {
-                    errors: Err("no value supplied for errors".to_string()),
-                }
-            }
-        }
-
-        impl GetCityCensusesResponse {
-            pub fn errors<T>(mut self, value: T) -> Self
-            where
-                T: ::std::convert::TryInto<::std::vec::Vec<super::ApiError>>,
-                T::Error: ::std::fmt::Display,
-            {
-                self.errors = value
-                    .try_into()
-                    .map_err(|e| format!("error converting supplied value for errors: {}", e));
-                self
-            }
-        }
-
-        impl ::std::convert::TryFrom<GetCityCensusesResponse> for super::GetCityCensusesResponse {
-            type Error = super::error::ConversionError;
-            fn try_from(
-                value: GetCityCensusesResponse,
-            ) -> ::std::result::Result<Self, super::error::ConversionError> {
-                Ok(Self {
-                    errors: value.errors?,
-                })
-            }
-        }
-
-        impl ::std::convert::From<super::GetCityCensusesResponse> for GetCityCensusesResponse {
-            fn from(value: super::GetCityCensusesResponse) -> Self {
-                Self {
-                    errors: Ok(value.errors),
-                }
-            }
-        }
-
-        #[derive(Clone, Debug)]
-        pub struct GetCityRatingsResponse {
-            errors: ::std::result::Result<::std::vec::Vec<super::ApiError>, ::std::string::String>,
-        }
-
-        impl ::std::default::Default for GetCityRatingsResponse {
-            fn default() -> Self {
-                Self {
-                    errors: Err("no value supplied for errors".to_string()),
-                }
-            }
-        }
-
-        impl GetCityRatingsResponse {
-            pub fn errors<T>(mut self, value: T) -> Self
-            where
-                T: ::std::convert::TryInto<::std::vec::Vec<super::ApiError>>,
-                T::Error: ::std::fmt::Display,
-            {
-                self.errors = value
-                    .try_into()
-                    .map_err(|e| format!("error converting supplied value for errors: {}", e));
-                self
-            }
-        }
-
-        impl ::std::convert::TryFrom<GetCityRatingsResponse> for super::GetCityRatingsResponse {
-            type Error = super::error::ConversionError;
-            fn try_from(
-                value: GetCityRatingsResponse,
-            ) -> ::std::result::Result<Self, super::error::ConversionError> {
-                Ok(Self {
-                    errors: value.errors?,
-                })
-            }
-        }
-
-        impl ::std::convert::From<super::GetCityRatingsResponse> for GetCityRatingsResponse {
-            fn from(value: super::GetCityRatingsResponse) -> Self {
-                Self {
-                    errors: Ok(value.errors),
-                }
-            }
-        }
-
-        #[derive(Clone, Debug)]
-        pub struct GetCityResponse {
-            errors: ::std::result::Result<::std::vec::Vec<super::ApiError>, ::std::string::String>,
-        }
-
-        impl ::std::default::Default for GetCityResponse {
-            fn default() -> Self {
-                Self {
-                    errors: Err("no value supplied for errors".to_string()),
-                }
-            }
-        }
-
-        impl GetCityResponse {
-            pub fn errors<T>(mut self, value: T) -> Self
-            where
-                T: ::std::convert::TryInto<::std::vec::Vec<super::ApiError>>,
-                T::Error: ::std::fmt::Display,
-            {
-                self.errors = value
-                    .try_into()
-                    .map_err(|e| format!("error converting supplied value for errors: {}", e));
-                self
-            }
-        }
-
-        impl ::std::convert::TryFrom<GetCityResponse> for super::GetCityResponse {
-            type Error = super::error::ConversionError;
-            fn try_from(
-                value: GetCityResponse,
-            ) -> ::std::result::Result<Self, super::error::ConversionError> {
-                Ok(Self {
-                    errors: value.errors?,
-                })
-            }
-        }
-
-        impl ::std::convert::From<super::GetCityResponse> for GetCityResponse {
-            fn from(value: super::GetCityResponse) -> Self {
-                Self {
-                    errors: Ok(value.errors),
-                }
-            }
-        }
-
-        #[derive(Clone, Debug)]
-        pub struct GetPipelinesBnaResponse {
-            errors: ::std::result::Result<::std::vec::Vec<super::ApiError>, ::std::string::String>,
-        }
-
-        impl ::std::default::Default for GetPipelinesBnaResponse {
-            fn default() -> Self {
-                Self {
-                    errors: Err("no value supplied for errors".to_string()),
-                }
-            }
-        }
-
-        impl GetPipelinesBnaResponse {
-            pub fn errors<T>(mut self, value: T) -> Self
-            where
-                T: ::std::convert::TryInto<::std::vec::Vec<super::ApiError>>,
-                T::Error: ::std::fmt::Display,
-            {
-                self.errors = value
-                    .try_into()
-                    .map_err(|e| format!("error converting supplied value for errors: {}", e));
-                self
-            }
-        }
-
-        impl ::std::convert::TryFrom<GetPipelinesBnaResponse> for super::GetPipelinesBnaResponse {
-            type Error = super::error::ConversionError;
-            fn try_from(
-                value: GetPipelinesBnaResponse,
-            ) -> ::std::result::Result<Self, super::error::ConversionError> {
-                Ok(Self {
-                    errors: value.errors?,
-                })
-            }
-        }
-
-        impl ::std::convert::From<super::GetPipelinesBnaResponse> for GetPipelinesBnaResponse {
-            fn from(value: super::GetPipelinesBnaResponse) -> Self {
-                Self {
-                    errors: Ok(value.errors),
-                }
-            }
-        }
-
-        #[derive(Clone, Debug)]
-        pub struct GetPipelinesBnasResponse {
-            errors: ::std::result::Result<::std::vec::Vec<super::ApiError>, ::std::string::String>,
-        }
-
-        impl ::std::default::Default for GetPipelinesBnasResponse {
-            fn default() -> Self {
-                Self {
-                    errors: Err("no value supplied for errors".to_string()),
-                }
-            }
-        }
-
-        impl GetPipelinesBnasResponse {
-            pub fn errors<T>(mut self, value: T) -> Self
-            where
-                T: ::std::convert::TryInto<::std::vec::Vec<super::ApiError>>,
-                T::Error: ::std::fmt::Display,
-            {
-                self.errors = value
-                    .try_into()
-                    .map_err(|e| format!("error converting supplied value for errors: {}", e));
-                self
-            }
-        }
-
-        impl ::std::convert::TryFrom<GetPipelinesBnasResponse> for super::GetPipelinesBnasResponse {
-            type Error = super::error::ConversionError;
-            fn try_from(
-                value: GetPipelinesBnasResponse,
-            ) -> ::std::result::Result<Self, super::error::ConversionError> {
-                Ok(Self {
-                    errors: value.errors?,
-                })
-            }
-        }
-
-        impl ::std::convert::From<super::GetPipelinesBnasResponse> for GetPipelinesBnasResponse {
-            fn from(value: super::GetPipelinesBnasResponse) -> Self {
-                Self {
-                    errors: Ok(value.errors),
-                }
-            }
-        }
-
-        #[derive(Clone, Debug)]
-        pub struct GetPriceFargateResponse {
-            errors: ::std::result::Result<::std::vec::Vec<super::ApiError>, ::std::string::String>,
-        }
-
-        impl ::std::default::Default for GetPriceFargateResponse {
-            fn default() -> Self {
-                Self {
-                    errors: Err("no value supplied for errors".to_string()),
-                }
-            }
-        }
-
-        impl GetPriceFargateResponse {
-            pub fn errors<T>(mut self, value: T) -> Self
-            where
-                T: ::std::convert::TryInto<::std::vec::Vec<super::ApiError>>,
-                T::Error: ::std::fmt::Display,
-            {
-                self.errors = value
-                    .try_into()
-                    .map_err(|e| format!("error converting supplied value for errors: {}", e));
-                self
-            }
-        }
-
-        impl ::std::convert::TryFrom<GetPriceFargateResponse> for super::GetPriceFargateResponse {
-            type Error = super::error::ConversionError;
-            fn try_from(
-                value: GetPriceFargateResponse,
-            ) -> ::std::result::Result<Self, super::error::ConversionError> {
-                Ok(Self {
-                    errors: value.errors?,
-                })
-            }
-        }
-
-        impl ::std::convert::From<super::GetPriceFargateResponse> for GetPriceFargateResponse {
-            fn from(value: super::GetPriceFargateResponse) -> Self {
-                Self {
-                    errors: Ok(value.errors),
-                }
-            }
-        }
-
-        #[derive(Clone, Debug)]
-        pub struct GetRatingResponse {
-            errors: ::std::result::Result<::std::vec::Vec<super::ApiError>, ::std::string::String>,
-        }
-
-        impl ::std::default::Default for GetRatingResponse {
-            fn default() -> Self {
-                Self {
-                    errors: Err("no value supplied for errors".to_string()),
-                }
-            }
-        }
-
-        impl GetRatingResponse {
-            pub fn errors<T>(mut self, value: T) -> Self
-            where
-                T: ::std::convert::TryInto<::std::vec::Vec<super::ApiError>>,
-                T::Error: ::std::fmt::Display,
-            {
-                self.errors = value
-                    .try_into()
-                    .map_err(|e| format!("error converting supplied value for errors: {}", e));
-                self
-            }
-        }
-
-        impl ::std::convert::TryFrom<GetRatingResponse> for super::GetRatingResponse {
-            type Error = super::error::ConversionError;
-            fn try_from(
-                value: GetRatingResponse,
-            ) -> ::std::result::Result<Self, super::error::ConversionError> {
-                Ok(Self {
-                    errors: value.errors?,
-                })
-            }
-        }
-
-        impl ::std::convert::From<super::GetRatingResponse> for GetRatingResponse {
-            fn from(value: super::GetRatingResponse) -> Self {
-                Self {
-                    errors: Ok(value.errors),
-                }
-            }
-        }
-
-        #[derive(Clone, Debug)]
-        pub struct GetRatingsCityResponse {
-            errors: ::std::result::Result<::std::vec::Vec<super::ApiError>, ::std::string::String>,
-        }
-
-        impl ::std::default::Default for GetRatingsCityResponse {
-            fn default() -> Self {
-                Self {
-                    errors: Err("no value supplied for errors".to_string()),
-                }
-            }
-        }
-
-        impl GetRatingsCityResponse {
-            pub fn errors<T>(mut self, value: T) -> Self
-            where
-                T: ::std::convert::TryInto<::std::vec::Vec<super::ApiError>>,
-                T::Error: ::std::fmt::Display,
-            {
-                self.errors = value
-                    .try_into()
-                    .map_err(|e| format!("error converting supplied value for errors: {}", e));
-                self
-            }
-        }
-
-        impl ::std::convert::TryFrom<GetRatingsCityResponse> for super::GetRatingsCityResponse {
-            type Error = super::error::ConversionError;
-            fn try_from(
-                value: GetRatingsCityResponse,
-            ) -> ::std::result::Result<Self, super::error::ConversionError> {
-                Ok(Self {
-                    errors: value.errors?,
-                })
-            }
-        }
-
-        impl ::std::convert::From<super::GetRatingsCityResponse> for GetRatingsCityResponse {
-            fn from(value: super::GetRatingsCityResponse) -> Self {
-                Self {
-                    errors: Ok(value.errors),
-                }
-            }
-        }
-
-        #[derive(Clone, Debug)]
         pub struct Infrastructure {
             high_stress_miles:
                 ::std::result::Result<::std::option::Option<f64>, ::std::string::String>,
@@ -5954,98 +4893,6 @@ pub mod types {
         }
 
         #[derive(Clone, Debug)]
-        pub struct PatchCitiesSubmissionResponse {
-            errors: ::std::result::Result<::std::vec::Vec<super::ApiError>, ::std::string::String>,
-        }
-
-        impl ::std::default::Default for PatchCitiesSubmissionResponse {
-            fn default() -> Self {
-                Self {
-                    errors: Err("no value supplied for errors".to_string()),
-                }
-            }
-        }
-
-        impl PatchCitiesSubmissionResponse {
-            pub fn errors<T>(mut self, value: T) -> Self
-            where
-                T: ::std::convert::TryInto<::std::vec::Vec<super::ApiError>>,
-                T::Error: ::std::fmt::Display,
-            {
-                self.errors = value
-                    .try_into()
-                    .map_err(|e| format!("error converting supplied value for errors: {}", e));
-                self
-            }
-        }
-
-        impl ::std::convert::TryFrom<PatchCitiesSubmissionResponse>
-            for super::PatchCitiesSubmissionResponse
-        {
-            type Error = super::error::ConversionError;
-            fn try_from(
-                value: PatchCitiesSubmissionResponse,
-            ) -> ::std::result::Result<Self, super::error::ConversionError> {
-                Ok(Self {
-                    errors: value.errors?,
-                })
-            }
-        }
-
-        impl ::std::convert::From<super::PatchCitiesSubmissionResponse> for PatchCitiesSubmissionResponse {
-            fn from(value: super::PatchCitiesSubmissionResponse) -> Self {
-                Self {
-                    errors: Ok(value.errors),
-                }
-            }
-        }
-
-        #[derive(Clone, Debug)]
-        pub struct PatchPipelinesBnaResponse {
-            errors: ::std::result::Result<::std::vec::Vec<super::ApiError>, ::std::string::String>,
-        }
-
-        impl ::std::default::Default for PatchPipelinesBnaResponse {
-            fn default() -> Self {
-                Self {
-                    errors: Err("no value supplied for errors".to_string()),
-                }
-            }
-        }
-
-        impl PatchPipelinesBnaResponse {
-            pub fn errors<T>(mut self, value: T) -> Self
-            where
-                T: ::std::convert::TryInto<::std::vec::Vec<super::ApiError>>,
-                T::Error: ::std::fmt::Display,
-            {
-                self.errors = value
-                    .try_into()
-                    .map_err(|e| format!("error converting supplied value for errors: {}", e));
-                self
-            }
-        }
-
-        impl ::std::convert::TryFrom<PatchPipelinesBnaResponse> for super::PatchPipelinesBnaResponse {
-            type Error = super::error::ConversionError;
-            fn try_from(
-                value: PatchPipelinesBnaResponse,
-            ) -> ::std::result::Result<Self, super::error::ConversionError> {
-                Ok(Self {
-                    errors: value.errors?,
-                })
-            }
-        }
-
-        impl ::std::convert::From<super::PatchPipelinesBnaResponse> for PatchPipelinesBnaResponse {
-            fn from(value: super::PatchPipelinesBnaResponse) -> Self {
-                Self {
-                    errors: Ok(value.errors),
-                }
-            }
-        }
-
-        #[derive(Clone, Debug)]
         pub struct People {
             people: ::std::result::Result<::std::option::Option<f64>, ::std::string::String>,
         }
@@ -6086,231 +4933,6 @@ pub mod types {
             fn from(value: super::People) -> Self {
                 Self {
                     people: Ok(value.people),
-                }
-            }
-        }
-
-        #[derive(Clone, Debug)]
-        pub struct PostCitiesSubmissionResponse {
-            errors: ::std::result::Result<::std::vec::Vec<super::ApiError>, ::std::string::String>,
-        }
-
-        impl ::std::default::Default for PostCitiesSubmissionResponse {
-            fn default() -> Self {
-                Self {
-                    errors: Err("no value supplied for errors".to_string()),
-                }
-            }
-        }
-
-        impl PostCitiesSubmissionResponse {
-            pub fn errors<T>(mut self, value: T) -> Self
-            where
-                T: ::std::convert::TryInto<::std::vec::Vec<super::ApiError>>,
-                T::Error: ::std::fmt::Display,
-            {
-                self.errors = value
-                    .try_into()
-                    .map_err(|e| format!("error converting supplied value for errors: {}", e));
-                self
-            }
-        }
-
-        impl ::std::convert::TryFrom<PostCitiesSubmissionResponse> for super::PostCitiesSubmissionResponse {
-            type Error = super::error::ConversionError;
-            fn try_from(
-                value: PostCitiesSubmissionResponse,
-            ) -> ::std::result::Result<Self, super::error::ConversionError> {
-                Ok(Self {
-                    errors: value.errors?,
-                })
-            }
-        }
-
-        impl ::std::convert::From<super::PostCitiesSubmissionResponse> for PostCitiesSubmissionResponse {
-            fn from(value: super::PostCitiesSubmissionResponse) -> Self {
-                Self {
-                    errors: Ok(value.errors),
-                }
-            }
-        }
-
-        #[derive(Clone, Debug)]
-        pub struct PostCityCensusResponse {
-            errors: ::std::result::Result<::std::vec::Vec<super::ApiError>, ::std::string::String>,
-        }
-
-        impl ::std::default::Default for PostCityCensusResponse {
-            fn default() -> Self {
-                Self {
-                    errors: Err("no value supplied for errors".to_string()),
-                }
-            }
-        }
-
-        impl PostCityCensusResponse {
-            pub fn errors<T>(mut self, value: T) -> Self
-            where
-                T: ::std::convert::TryInto<::std::vec::Vec<super::ApiError>>,
-                T::Error: ::std::fmt::Display,
-            {
-                self.errors = value
-                    .try_into()
-                    .map_err(|e| format!("error converting supplied value for errors: {}", e));
-                self
-            }
-        }
-
-        impl ::std::convert::TryFrom<PostCityCensusResponse> for super::PostCityCensusResponse {
-            type Error = super::error::ConversionError;
-            fn try_from(
-                value: PostCityCensusResponse,
-            ) -> ::std::result::Result<Self, super::error::ConversionError> {
-                Ok(Self {
-                    errors: value.errors?,
-                })
-            }
-        }
-
-        impl ::std::convert::From<super::PostCityCensusResponse> for PostCityCensusResponse {
-            fn from(value: super::PostCityCensusResponse) -> Self {
-                Self {
-                    errors: Ok(value.errors),
-                }
-            }
-        }
-
-        #[derive(Clone, Debug)]
-        pub struct PostCityResponse {
-            errors: ::std::result::Result<::std::vec::Vec<super::ApiError>, ::std::string::String>,
-        }
-
-        impl ::std::default::Default for PostCityResponse {
-            fn default() -> Self {
-                Self {
-                    errors: Err("no value supplied for errors".to_string()),
-                }
-            }
-        }
-
-        impl PostCityResponse {
-            pub fn errors<T>(mut self, value: T) -> Self
-            where
-                T: ::std::convert::TryInto<::std::vec::Vec<super::ApiError>>,
-                T::Error: ::std::fmt::Display,
-            {
-                self.errors = value
-                    .try_into()
-                    .map_err(|e| format!("error converting supplied value for errors: {}", e));
-                self
-            }
-        }
-
-        impl ::std::convert::TryFrom<PostCityResponse> for super::PostCityResponse {
-            type Error = super::error::ConversionError;
-            fn try_from(
-                value: PostCityResponse,
-            ) -> ::std::result::Result<Self, super::error::ConversionError> {
-                Ok(Self {
-                    errors: value.errors?,
-                })
-            }
-        }
-
-        impl ::std::convert::From<super::PostCityResponse> for PostCityResponse {
-            fn from(value: super::PostCityResponse) -> Self {
-                Self {
-                    errors: Ok(value.errors),
-                }
-            }
-        }
-
-        #[derive(Clone, Debug)]
-        pub struct PostPipelinesBnaResponse {
-            errors: ::std::result::Result<::std::vec::Vec<super::ApiError>, ::std::string::String>,
-        }
-
-        impl ::std::default::Default for PostPipelinesBnaResponse {
-            fn default() -> Self {
-                Self {
-                    errors: Err("no value supplied for errors".to_string()),
-                }
-            }
-        }
-
-        impl PostPipelinesBnaResponse {
-            pub fn errors<T>(mut self, value: T) -> Self
-            where
-                T: ::std::convert::TryInto<::std::vec::Vec<super::ApiError>>,
-                T::Error: ::std::fmt::Display,
-            {
-                self.errors = value
-                    .try_into()
-                    .map_err(|e| format!("error converting supplied value for errors: {}", e));
-                self
-            }
-        }
-
-        impl ::std::convert::TryFrom<PostPipelinesBnaResponse> for super::PostPipelinesBnaResponse {
-            type Error = super::error::ConversionError;
-            fn try_from(
-                value: PostPipelinesBnaResponse,
-            ) -> ::std::result::Result<Self, super::error::ConversionError> {
-                Ok(Self {
-                    errors: value.errors?,
-                })
-            }
-        }
-
-        impl ::std::convert::From<super::PostPipelinesBnaResponse> for PostPipelinesBnaResponse {
-            fn from(value: super::PostPipelinesBnaResponse) -> Self {
-                Self {
-                    errors: Ok(value.errors),
-                }
-            }
-        }
-
-        #[derive(Clone, Debug)]
-        pub struct PostRatingResponse {
-            errors: ::std::result::Result<::std::vec::Vec<super::ApiError>, ::std::string::String>,
-        }
-
-        impl ::std::default::Default for PostRatingResponse {
-            fn default() -> Self {
-                Self {
-                    errors: Err("no value supplied for errors".to_string()),
-                }
-            }
-        }
-
-        impl PostRatingResponse {
-            pub fn errors<T>(mut self, value: T) -> Self
-            where
-                T: ::std::convert::TryInto<::std::vec::Vec<super::ApiError>>,
-                T::Error: ::std::fmt::Display,
-            {
-                self.errors = value
-                    .try_into()
-                    .map_err(|e| format!("error converting supplied value for errors: {}", e));
-                self
-            }
-        }
-
-        impl ::std::convert::TryFrom<PostRatingResponse> for super::PostRatingResponse {
-            type Error = super::error::ConversionError;
-            fn try_from(
-                value: PostRatingResponse,
-            ) -> ::std::result::Result<Self, super::error::ConversionError> {
-                Ok(Self {
-                    errors: value.errors?,
-                })
-            }
-        }
-
-        impl ::std::convert::From<super::PostRatingResponse> for PostRatingResponse {
-            fn from(value: super::PostRatingResponse) -> Self {
-                Self {
-                    errors: Ok(value.errors),
                 }
             }
         }
@@ -8170,9 +6792,7 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/cities`
-        pub async fn send(
-            self,
-        ) -> Result<ResponseValue<types::City>, Error<types::PostCityResponse>> {
+        pub async fn send(self) -> Result<ResponseValue<types::City>, Error<types::ApiErrors>> {
             let Self { client, body } = self;
             let body = body
                 .and_then(|v| types::CityPost::try_from(v).map_err(|e| e.to_string()))
@@ -8265,8 +6885,7 @@ pub mod builder {
         ///Sends a `GET` request to `/cities/submissions`
         pub async fn send(
             self,
-        ) -> Result<ResponseValue<types::Submissions>, Error<types::GetCitiesSubmissionsResponse>>
-        {
+        ) -> Result<ResponseValue<types::Submissions>, Error<types::ApiErrors>> {
             let Self {
                 client,
                 page,
@@ -8358,8 +6977,7 @@ pub mod builder {
         ///Sends a `POST` request to `/cities/submissions`
         pub async fn send(
             self,
-        ) -> Result<ResponseValue<types::Submission>, Error<types::PostCitiesSubmissionResponse>>
-        {
+        ) -> Result<ResponseValue<types::Submission>, Error<types::ApiErrors>> {
             let Self { client, body } = self;
             let body = body
                 .and_then(|v| types::SubmissionPost::try_from(v).map_err(|e| e.to_string()))
@@ -8438,8 +7056,7 @@ pub mod builder {
         ///Sends a `GET` request to `/cities/submissions/{submission_id}`
         pub async fn send(
             self,
-        ) -> Result<ResponseValue<types::Submission>, Error<types::GetCitiesSubmissionResponse>>
-        {
+        ) -> Result<ResponseValue<types::Submission>, Error<types::ApiErrors>> {
             let Self {
                 client,
                 submission_id,
@@ -8539,8 +7156,7 @@ pub mod builder {
         ///Sends a `PATCH` request to `/cities/submissions/{submission_id}`
         pub async fn send(
             self,
-        ) -> Result<ResponseValue<types::Submission>, Error<types::PatchCitiesSubmissionResponse>>
-        {
+        ) -> Result<ResponseValue<types::Submission>, Error<types::ApiErrors>> {
             let Self {
                 client,
                 submission_id,
@@ -8638,9 +7254,7 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/cities/{country}/{region}/{name}`
-        pub async fn send(
-            self,
-        ) -> Result<ResponseValue<types::City>, Error<types::GetCityResponse>> {
+        pub async fn send(self) -> Result<ResponseValue<types::City>, Error<types::ApiErrors>> {
             let Self {
                 client,
                 country,
@@ -8767,8 +7381,7 @@ pub mod builder {
         ///Sends a `GET` request to `/cities/{country}/{region}/{name}/census`
         pub async fn send(
             self,
-        ) -> Result<ResponseValue<types::CityCensuses>, Error<types::GetCityCensusesResponse>>
-        {
+        ) -> Result<ResponseValue<types::CityCensuses>, Error<types::ApiErrors>> {
             let Self {
                 client,
                 country,
@@ -8901,9 +7514,7 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/cities/{country}/{region}/{name}/census`
-        pub async fn send(
-            self,
-        ) -> Result<ResponseValue<types::Census>, Error<types::PostCityCensusResponse>> {
+        pub async fn send(self) -> Result<ResponseValue<types::Census>, Error<types::ApiErrors>> {
             let Self {
                 client,
                 country,
@@ -9035,8 +7646,7 @@ pub mod builder {
         ///Sends a `GET` request to `/cities/{country}/{region}/{name}/ratings`
         pub async fn send(
             self,
-        ) -> Result<ResponseValue<types::CityRatings>, Error<types::GetCityRatingsResponse>>
-        {
+        ) -> Result<ResponseValue<types::CityRatings>, Error<types::ApiErrors>> {
             let Self {
                 client,
                 country,
@@ -9139,8 +7749,7 @@ pub mod builder {
         ///Sends a `GET` request to `/pipelines/bna`
         pub async fn send(
             self,
-        ) -> Result<ResponseValue<types::BnaPipelines>, Error<types::GetPipelinesBnasResponse>>
-        {
+        ) -> Result<ResponseValue<types::BnaPipelines>, Error<types::ApiErrors>> {
             let Self {
                 client,
                 page,
@@ -9227,8 +7836,7 @@ pub mod builder {
         ///Sends a `POST` request to `/pipelines/bna`
         pub async fn send(
             self,
-        ) -> Result<ResponseValue<types::BnaPipeline>, Error<types::PostPipelinesBnaResponse>>
-        {
+        ) -> Result<ResponseValue<types::BnaPipeline>, Error<types::ApiErrors>> {
             let Self { client, body } = self;
             let body = body
                 .and_then(|v| types::BnaPipelinePost::try_from(v).map_err(|e| e.to_string()))
@@ -9295,8 +7903,7 @@ pub mod builder {
         ///Sends a `GET` request to `/pipelines/bna/{pipeline_id}`
         pub async fn send(
             self,
-        ) -> Result<ResponseValue<types::BnaPipeline>, Error<types::GetPipelinesBnaResponse>>
-        {
+        ) -> Result<ResponseValue<types::BnaPipeline>, Error<types::ApiErrors>> {
             let Self {
                 client,
                 pipeline_id,
@@ -9391,8 +7998,7 @@ pub mod builder {
         ///Sends a `PATCH` request to `/pipelines/bna/{pipeline_id}`
         pub async fn send(
             self,
-        ) -> Result<ResponseValue<types::BnaPipeline>, Error<types::PatchPipelinesBnaResponse>>
-        {
+        ) -> Result<ResponseValue<types::BnaPipeline>, Error<types::ApiErrors>> {
             let Self {
                 client,
                 pipeline_id,
@@ -9545,8 +8151,7 @@ pub mod builder {
         ///Sends a `GET` request to `/prices/fargate/{price_id}`
         pub async fn send(
             self,
-        ) -> Result<ResponseValue<types::FargatePrice>, Error<types::GetPriceFargateResponse>>
-        {
+        ) -> Result<ResponseValue<types::FargatePrice>, Error<types::ApiErrors>> {
             let Self { client, price_id } = self;
             let price_id = price_id.map_err(Error::InvalidRequest)?;
             let url = format!(
@@ -9699,9 +8304,7 @@ pub mod builder {
         }
 
         ///Sends a `POST` request to `/ratings`
-        pub async fn send(
-            self,
-        ) -> Result<ResponseValue<types::Rating>, Error<types::PostRatingResponse>> {
+        pub async fn send(self) -> Result<ResponseValue<types::Rating>, Error<types::ApiErrors>> {
             let Self { client, body } = self;
             let body = body
                 .and_then(|v| types::RatingPost::try_from(v).map_err(|e| e.to_string()))
@@ -9766,9 +8369,7 @@ pub mod builder {
         }
 
         ///Sends a `GET` request to `/ratings/{rating_id}`
-        pub async fn send(
-            self,
-        ) -> Result<ResponseValue<types::Rating>, Error<types::GetRatingResponse>> {
+        pub async fn send(self) -> Result<ResponseValue<types::Rating>, Error<types::ApiErrors>> {
             let Self { client, rating_id } = self;
             let rating_id = rating_id.map_err(Error::InvalidRequest)?;
             let url = format!(
@@ -9836,8 +8437,7 @@ pub mod builder {
         ///Sends a `GET` request to `/ratings/{rating_id}/city`
         pub async fn send(
             self,
-        ) -> Result<ResponseValue<types::RatingWithCity>, Error<types::GetRatingsCityResponse>>
-        {
+        ) -> Result<ResponseValue<types::RatingWithCity>, Error<types::ApiErrors>> {
             let Self { client, rating_id } = self;
             let rating_id = rating_id.map_err(Error::InvalidRequest)?;
             let url = format!(

--- a/lambdas/src/core/resource/schema.rs
+++ b/lambdas/src/core/resource/schema.rs
@@ -172,7 +172,7 @@ pub struct APIError {
 /// Error objects MUST be returned as an array keyed by errors in the top level of a
 /// JSON:API document.
 #[derive(Deserialize, Serialize, ToSchema)]
-pub(crate) struct APIErrors {
+pub struct APIErrors {
     pub errors: Vec<APIError>,
 }
 
@@ -183,54 +183,66 @@ pub(crate) enum ErrorResponses {
     #[response(
         status = 400,
         description = "The request was formatted incorrectly or missing required parameters.",
-        example = json!([{
-          "details": "the request was formatted incorrectly or missing required parameters",
-          "id": "blfwkg8nvHcEJnQ=",
-          "source": {"parameter": "status"},
-          "status": "400",
-          "title": "Bad Request"
-        }])
+        example = json!({
+          "errors": [
+          {
+            "details": "the request was formatted incorrectly or missing required parameters",
+            "id": "blfwkg8nvHcEJnQ=",
+            "source": {"parameter": "status"},
+            "status": "400",
+            "title": "Bad Request"
+          }
+        ]})
     )]
-    BadRequest(#[to_schema] APIErrors),
+    BadRequest(APIErrors),
     /// Unauthorized
     #[response(
       status = 401,
       description = "The request has not been fulfilled because it lacks valid authentication credentials for the target resource.",
-      example = json!([{
-        "details": "invalid authentication credentials to access the specified resource",
-        "id": "blfwkg8nvHcEJnQ=",
-        "source": {"pointer": "/bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221"},
-        "status": "401",
-        "title": "Unauthorized"
-      }])
+      example = json!({
+        "errors": [
+        {
+          "details": "invalid authentication credentials to access the specified resource",
+          "id": "blfwkg8nvHcEJnQ=",
+          "source": {"pointer": "/bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221"},
+          "status": "401",
+          "title": "Unauthorized"
+        }
+      ]})
   )]
-    Unauthorized(#[to_schema] APIErrors),
+    Unauthorized(APIErrors),
     /// Forbidden
     #[response(
       status = 403,
       description = "Forbidden to make the request. Most likely this indicates an issue with the credentials or permissions.",
-      example = json!([{
-        "details": "access to the requested resource is forbidden",
-        "id": "blfwkg8nvHcEJnQ=",
-        "source": {"pointer": "/bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221"},
-        "status": "403",
-        "title": "Forbidden"
-      }])
+      example = json!({
+        "errors": [
+        {
+          "details": "access to the requested resource is forbidden",
+          "id": "blfwkg8nvHcEJnQ=",
+          "source": {"pointer": "/bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221"},
+          "status": "403",
+          "title": "Forbidden"
+        }
+      ]})
   )]
-    Forbidden(#[to_schema] APIErrors),
+    Forbidden(APIErrors),
     /// Item Not Found
     #[response(
         status = 404,
         description = "The particular resource requested was not found. This occurs, for example, when the id of the requested  resource does not exist.",
-        example = json!([{
-          "details": "the resource was not found",
-          "id": "blfwkg8nvHcEJnQ=",
-          "source": {"pointer": "/bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221"},
-          "status": "404",
-          "title": "Item Not Found"
-        }])
+        example = json!({
+          "errors": [
+            {
+              "details": "the resource was not found",
+              "id": "blfwkg8nvHcEJnQ=",
+              "source": {"pointer": "/bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221"},
+              "status": "404",
+              "title": "Item Not Found"
+            }
+          ]})
     )]
-    NotFound(#[to_schema] APIErrors),
+    NotFound(APIErrors),
 }
 
 #[allow(dead_code)]

--- a/lambdas/src/main.rs
+++ b/lambdas/src/main.rs
@@ -2,7 +2,7 @@ use ::tracing::{debug, info};
 use lambda_http::{run, tracing, Error};
 use lambdas::core::resource::{
     cities, pipelines, price, ratings,
-    schema::{APIError, APIErrorSource},
+    schema::{APIError, APIErrorSource, APIErrors},
 };
 use std::{
     env::{self, set_var},
@@ -104,6 +104,13 @@ async fn main() -> Result<(), Error> {
                     schema!(
                         #[inline]
                         APIErrorSource
+                    ),
+                )
+                .schema(
+                    "APIErrors",
+                    schema!(
+                        #[inline]
+                        APIErrors
                     ),
                 )
                 .build(),

--- a/openapi-3.0.yaml
+++ b/openapi-3.0.yaml
@@ -71,28 +71,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: >-
-                    the request was formatted incorrectly or missing required
-                    parameters
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    parameter: status
-                  status: '400'
-                  title: Bad Request
+                errors:
+                  - details: >-
+                      the request was formatted incorrectly or missing required
+                      parameters
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      parameter: status
+                    status: '400'
+                    title: Bad Request
         '401':
           description: >-
             The request has not been fulfilled because it lacks valid
@@ -100,28 +89,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: >-
-                    invalid authentication credentials to access the specified
-                    resource
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '401'
-                  title: Unauthorized
+                errors:
+                  - details: >-
+                      invalid authentication credentials to access the specified
+                      resource
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '401'
+                    title: Unauthorized
         '403':
           description: >-
             Forbidden to make the request. Most likely this indicates an issue
@@ -129,26 +107,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: access to the requested resource is forbidden
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '403'
-                  title: Forbidden
+                errors:
+                  - details: access to the requested resource is forbidden
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '403'
+                    title: Forbidden
         '404':
           description: >-
             The particular resource requested was not found. This occurs, for
@@ -156,26 +123,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: the resource was not found
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '404'
-                  title: Item Not Found
+                errors:
+                  - details: the resource was not found
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '404'
+                    title: Item Not Found
   /cities/submissions:
     get:
       tags:
@@ -224,28 +180,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: >-
-                    the request was formatted incorrectly or missing required
-                    parameters
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    parameter: status
-                  status: '400'
-                  title: Bad Request
+                errors:
+                  - details: >-
+                      the request was formatted incorrectly or missing required
+                      parameters
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      parameter: status
+                    status: '400'
+                    title: Bad Request
         '401':
           description: >-
             The request has not been fulfilled because it lacks valid
@@ -253,28 +198,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: >-
-                    invalid authentication credentials to access the specified
-                    resource
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '401'
-                  title: Unauthorized
+                errors:
+                  - details: >-
+                      invalid authentication credentials to access the specified
+                      resource
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '401'
+                    title: Unauthorized
         '403':
           description: >-
             Forbidden to make the request. Most likely this indicates an issue
@@ -282,26 +216,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: access to the requested resource is forbidden
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '403'
-                  title: Forbidden
+                errors:
+                  - details: access to the requested resource is forbidden
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '403'
+                    title: Forbidden
         '404':
           description: >-
             The particular resource requested was not found. This occurs, for
@@ -309,26 +232,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: the resource was not found
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '404'
-                  title: Item Not Found
+                errors:
+                  - details: the resource was not found
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '404'
+                    title: Item Not Found
     post:
       tags:
         - city
@@ -354,28 +266,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: >-
-                    the request was formatted incorrectly or missing required
-                    parameters
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    parameter: status
-                  status: '400'
-                  title: Bad Request
+                errors:
+                  - details: >-
+                      the request was formatted incorrectly or missing required
+                      parameters
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      parameter: status
+                    status: '400'
+                    title: Bad Request
         '401':
           description: >-
             The request has not been fulfilled because it lacks valid
@@ -383,28 +284,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: >-
-                    invalid authentication credentials to access the specified
-                    resource
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '401'
-                  title: Unauthorized
+                errors:
+                  - details: >-
+                      invalid authentication credentials to access the specified
+                      resource
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '401'
+                    title: Unauthorized
         '403':
           description: >-
             Forbidden to make the request. Most likely this indicates an issue
@@ -412,26 +302,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: access to the requested resource is forbidden
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '403'
-                  title: Forbidden
+                errors:
+                  - details: access to the requested resource is forbidden
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '403'
+                    title: Forbidden
         '404':
           description: >-
             The particular resource requested was not found. This occurs, for
@@ -439,26 +318,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: the resource was not found
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '404'
-                  title: Item Not Found
+                errors:
+                  - details: the resource was not found
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '404'
+                    title: Item Not Found
   /cities/submissions/{submission_id}:
     get:
       tags:
@@ -495,28 +363,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: >-
-                    the request was formatted incorrectly or missing required
-                    parameters
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    parameter: status
-                  status: '400'
-                  title: Bad Request
+                errors:
+                  - details: >-
+                      the request was formatted incorrectly or missing required
+                      parameters
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      parameter: status
+                    status: '400'
+                    title: Bad Request
         '401':
           description: >-
             The request has not been fulfilled because it lacks valid
@@ -524,28 +381,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: >-
-                    invalid authentication credentials to access the specified
-                    resource
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '401'
-                  title: Unauthorized
+                errors:
+                  - details: >-
+                      invalid authentication credentials to access the specified
+                      resource
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '401'
+                    title: Unauthorized
         '403':
           description: >-
             Forbidden to make the request. Most likely this indicates an issue
@@ -553,26 +399,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: access to the requested resource is forbidden
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '403'
-                  title: Forbidden
+                errors:
+                  - details: access to the requested resource is forbidden
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '403'
+                    title: Forbidden
         '404':
           description: >-
             The particular resource requested was not found. This occurs, for
@@ -580,26 +415,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: the resource was not found
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '404'
-                  title: Item Not Found
+                errors:
+                  - details: the resource was not found
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '404'
+                    title: Item Not Found
     patch:
       tags:
         - city
@@ -634,28 +458,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: >-
-                    the request was formatted incorrectly or missing required
-                    parameters
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    parameter: status
-                  status: '400'
-                  title: Bad Request
+                errors:
+                  - details: >-
+                      the request was formatted incorrectly or missing required
+                      parameters
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      parameter: status
+                    status: '400'
+                    title: Bad Request
         '401':
           description: >-
             The request has not been fulfilled because it lacks valid
@@ -663,28 +476,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: >-
-                    invalid authentication credentials to access the specified
-                    resource
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '401'
-                  title: Unauthorized
+                errors:
+                  - details: >-
+                      invalid authentication credentials to access the specified
+                      resource
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '401'
+                    title: Unauthorized
         '403':
           description: >-
             Forbidden to make the request. Most likely this indicates an issue
@@ -692,26 +494,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: access to the requested resource is forbidden
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '403'
-                  title: Forbidden
+                errors:
+                  - details: access to the requested resource is forbidden
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '403'
+                    title: Forbidden
         '404':
           description: >-
             The particular resource requested was not found. This occurs, for
@@ -719,26 +510,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: the resource was not found
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '404'
-                  title: Item Not Found
+                errors:
+                  - details: the resource was not found
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '404'
+                    title: Item Not Found
   /cities/{country}/{region}/{name}:
     get:
       tags:
@@ -787,28 +567,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: >-
-                    the request was formatted incorrectly or missing required
-                    parameters
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    parameter: status
-                  status: '400'
-                  title: Bad Request
+                errors:
+                  - details: >-
+                      the request was formatted incorrectly or missing required
+                      parameters
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      parameter: status
+                    status: '400'
+                    title: Bad Request
         '401':
           description: >-
             The request has not been fulfilled because it lacks valid
@@ -816,28 +585,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: >-
-                    invalid authentication credentials to access the specified
-                    resource
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '401'
-                  title: Unauthorized
+                errors:
+                  - details: >-
+                      invalid authentication credentials to access the specified
+                      resource
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '401'
+                    title: Unauthorized
         '403':
           description: >-
             Forbidden to make the request. Most likely this indicates an issue
@@ -845,26 +603,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: access to the requested resource is forbidden
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '403'
-                  title: Forbidden
+                errors:
+                  - details: access to the requested resource is forbidden
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '403'
+                    title: Forbidden
         '404':
           description: >-
             The particular resource requested was not found. This occurs, for
@@ -872,26 +619,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: the resource was not found
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '404'
-                  title: Item Not Found
+                errors:
+                  - details: the resource was not found
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '404'
+                    title: Item Not Found
   /cities/{country}/{region}/{name}/census:
     get:
       tags:
@@ -962,28 +698,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: >-
-                    the request was formatted incorrectly or missing required
-                    parameters
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    parameter: status
-                  status: '400'
-                  title: Bad Request
+                errors:
+                  - details: >-
+                      the request was formatted incorrectly or missing required
+                      parameters
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      parameter: status
+                    status: '400'
+                    title: Bad Request
         '401':
           description: >-
             The request has not been fulfilled because it lacks valid
@@ -991,28 +716,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: >-
-                    invalid authentication credentials to access the specified
-                    resource
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '401'
-                  title: Unauthorized
+                errors:
+                  - details: >-
+                      invalid authentication credentials to access the specified
+                      resource
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '401'
+                    title: Unauthorized
         '403':
           description: >-
             Forbidden to make the request. Most likely this indicates an issue
@@ -1020,26 +734,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: access to the requested resource is forbidden
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '403'
-                  title: Forbidden
+                errors:
+                  - details: access to the requested resource is forbidden
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '403'
+                    title: Forbidden
         '404':
           description: >-
             The particular resource requested was not found. This occurs, for
@@ -1047,26 +750,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: the resource was not found
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '404'
-                  title: Item Not Found
+                errors:
+                  - details: the resource was not found
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '404'
+                    title: Item Not Found
     post:
       tags:
         - city
@@ -1120,28 +812,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: >-
-                    the request was formatted incorrectly or missing required
-                    parameters
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    parameter: status
-                  status: '400'
-                  title: Bad Request
+                errors:
+                  - details: >-
+                      the request was formatted incorrectly or missing required
+                      parameters
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      parameter: status
+                    status: '400'
+                    title: Bad Request
         '401':
           description: >-
             The request has not been fulfilled because it lacks valid
@@ -1149,28 +830,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: >-
-                    invalid authentication credentials to access the specified
-                    resource
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '401'
-                  title: Unauthorized
+                errors:
+                  - details: >-
+                      invalid authentication credentials to access the specified
+                      resource
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '401'
+                    title: Unauthorized
         '403':
           description: >-
             Forbidden to make the request. Most likely this indicates an issue
@@ -1178,26 +848,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: access to the requested resource is forbidden
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '403'
-                  title: Forbidden
+                errors:
+                  - details: access to the requested resource is forbidden
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '403'
+                    title: Forbidden
         '404':
           description: >-
             The particular resource requested was not found. This occurs, for
@@ -1205,26 +864,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: the resource was not found
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '404'
-                  title: Item Not Found
+                errors:
+                  - details: the resource was not found
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '404'
+                    title: Item Not Found
   /cities/{country}/{region}/{name}/ratings:
     get:
       tags:
@@ -1295,28 +943,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: >-
-                    the request was formatted incorrectly or missing required
-                    parameters
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    parameter: status
-                  status: '400'
-                  title: Bad Request
+                errors:
+                  - details: >-
+                      the request was formatted incorrectly or missing required
+                      parameters
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      parameter: status
+                    status: '400'
+                    title: Bad Request
         '401':
           description: >-
             The request has not been fulfilled because it lacks valid
@@ -1324,28 +961,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: >-
-                    invalid authentication credentials to access the specified
-                    resource
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '401'
-                  title: Unauthorized
+                errors:
+                  - details: >-
+                      invalid authentication credentials to access the specified
+                      resource
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '401'
+                    title: Unauthorized
         '403':
           description: >-
             Forbidden to make the request. Most likely this indicates an issue
@@ -1353,26 +979,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: access to the requested resource is forbidden
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '403'
-                  title: Forbidden
+                errors:
+                  - details: access to the requested resource is forbidden
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '403'
+                    title: Forbidden
         '404':
           description: >-
             The particular resource requested was not found. This occurs, for
@@ -1380,26 +995,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: the resource was not found
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '404'
-                  title: Item Not Found
+                errors:
+                  - details: the resource was not found
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '404'
+                    title: Item Not Found
   /pipelines/bna:
     get:
       tags:
@@ -1441,28 +1045,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: >-
-                    the request was formatted incorrectly or missing required
-                    parameters
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    parameter: status
-                  status: '400'
-                  title: Bad Request
+                errors:
+                  - details: >-
+                      the request was formatted incorrectly or missing required
+                      parameters
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      parameter: status
+                    status: '400'
+                    title: Bad Request
         '401':
           description: >-
             The request has not been fulfilled because it lacks valid
@@ -1470,28 +1063,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: >-
-                    invalid authentication credentials to access the specified
-                    resource
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '401'
-                  title: Unauthorized
+                errors:
+                  - details: >-
+                      invalid authentication credentials to access the specified
+                      resource
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '401'
+                    title: Unauthorized
         '403':
           description: >-
             Forbidden to make the request. Most likely this indicates an issue
@@ -1499,26 +1081,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: access to the requested resource is forbidden
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '403'
-                  title: Forbidden
+                errors:
+                  - details: access to the requested resource is forbidden
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '403'
+                    title: Forbidden
         '404':
           description: >-
             The particular resource requested was not found. This occurs, for
@@ -1526,26 +1097,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: the resource was not found
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '404'
-                  title: Item Not Found
+                errors:
+                  - details: the resource was not found
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '404'
+                    title: Item Not Found
     post:
       tags:
         - pipeline
@@ -1571,28 +1131,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: >-
-                    the request was formatted incorrectly or missing required
-                    parameters
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    parameter: status
-                  status: '400'
-                  title: Bad Request
+                errors:
+                  - details: >-
+                      the request was formatted incorrectly or missing required
+                      parameters
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      parameter: status
+                    status: '400'
+                    title: Bad Request
         '401':
           description: >-
             The request has not been fulfilled because it lacks valid
@@ -1600,28 +1149,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: >-
-                    invalid authentication credentials to access the specified
-                    resource
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '401'
-                  title: Unauthorized
+                errors:
+                  - details: >-
+                      invalid authentication credentials to access the specified
+                      resource
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '401'
+                    title: Unauthorized
         '403':
           description: >-
             Forbidden to make the request. Most likely this indicates an issue
@@ -1629,26 +1167,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: access to the requested resource is forbidden
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '403'
-                  title: Forbidden
+                errors:
+                  - details: access to the requested resource is forbidden
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '403'
+                    title: Forbidden
         '404':
           description: >-
             The particular resource requested was not found. This occurs, for
@@ -1656,26 +1183,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: the resource was not found
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '404'
-                  title: Item Not Found
+                errors:
+                  - details: the resource was not found
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '404'
+                    title: Item Not Found
   /pipelines/bna/{pipeline_id}:
     get:
       tags:
@@ -1704,28 +1220,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: >-
-                    the request was formatted incorrectly or missing required
-                    parameters
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    parameter: status
-                  status: '400'
-                  title: Bad Request
+                errors:
+                  - details: >-
+                      the request was formatted incorrectly or missing required
+                      parameters
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      parameter: status
+                    status: '400'
+                    title: Bad Request
         '401':
           description: >-
             The request has not been fulfilled because it lacks valid
@@ -1733,28 +1238,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: >-
-                    invalid authentication credentials to access the specified
-                    resource
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '401'
-                  title: Unauthorized
+                errors:
+                  - details: >-
+                      invalid authentication credentials to access the specified
+                      resource
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '401'
+                    title: Unauthorized
         '403':
           description: >-
             Forbidden to make the request. Most likely this indicates an issue
@@ -1762,26 +1256,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: access to the requested resource is forbidden
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '403'
-                  title: Forbidden
+                errors:
+                  - details: access to the requested resource is forbidden
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '403'
+                    title: Forbidden
         '404':
           description: >-
             The particular resource requested was not found. This occurs, for
@@ -1789,26 +1272,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: the resource was not found
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '404'
-                  title: Item Not Found
+                errors:
+                  - details: the resource was not found
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '404'
+                    title: Item Not Found
     patch:
       tags:
         - pipeline
@@ -1842,28 +1314,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: >-
-                    the request was formatted incorrectly or missing required
-                    parameters
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    parameter: status
-                  status: '400'
-                  title: Bad Request
+                errors:
+                  - details: >-
+                      the request was formatted incorrectly or missing required
+                      parameters
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      parameter: status
+                    status: '400'
+                    title: Bad Request
         '401':
           description: >-
             The request has not been fulfilled because it lacks valid
@@ -1871,28 +1332,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: >-
-                    invalid authentication credentials to access the specified
-                    resource
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '401'
-                  title: Unauthorized
+                errors:
+                  - details: >-
+                      invalid authentication credentials to access the specified
+                      resource
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '401'
+                    title: Unauthorized
         '403':
           description: >-
             Forbidden to make the request. Most likely this indicates an issue
@@ -1900,26 +1350,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: access to the requested resource is forbidden
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '403'
-                  title: Forbidden
+                errors:
+                  - details: access to the requested resource is forbidden
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '403'
+                    title: Forbidden
         '404':
           description: >-
             The particular resource requested was not found. This occurs, for
@@ -1927,26 +1366,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: the resource was not found
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '404'
-                  title: Item Not Found
+                errors:
+                  - details: the resource was not found
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '404'
+                    title: Item Not Found
   /prices/fargate:
     get:
       tags:
@@ -2011,28 +1439,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: >-
-                    the request was formatted incorrectly or missing required
-                    parameters
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    parameter: status
-                  status: '400'
-                  title: Bad Request
+                errors:
+                  - details: >-
+                      the request was formatted incorrectly or missing required
+                      parameters
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      parameter: status
+                    status: '400'
+                    title: Bad Request
         '401':
           description: >-
             The request has not been fulfilled because it lacks valid
@@ -2040,28 +1457,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: >-
-                    invalid authentication credentials to access the specified
-                    resource
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '401'
-                  title: Unauthorized
+                errors:
+                  - details: >-
+                      invalid authentication credentials to access the specified
+                      resource
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '401'
+                    title: Unauthorized
         '403':
           description: >-
             Forbidden to make the request. Most likely this indicates an issue
@@ -2069,26 +1475,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: access to the requested resource is forbidden
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '403'
-                  title: Forbidden
+                errors:
+                  - details: access to the requested resource is forbidden
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '403'
+                    title: Forbidden
         '404':
           description: >-
             The particular resource requested was not found. This occurs, for
@@ -2096,26 +1491,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: the resource was not found
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '404'
-                  title: Item Not Found
+                errors:
+                  - details: the resource was not found
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '404'
+                    title: Item Not Found
   /ratings:
     get:
       tags:
@@ -2175,28 +1559,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: >-
-                    the request was formatted incorrectly or missing required
-                    parameters
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    parameter: status
-                  status: '400'
-                  title: Bad Request
+                errors:
+                  - details: >-
+                      the request was formatted incorrectly or missing required
+                      parameters
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      parameter: status
+                    status: '400'
+                    title: Bad Request
         '401':
           description: >-
             The request has not been fulfilled because it lacks valid
@@ -2204,28 +1577,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: >-
-                    invalid authentication credentials to access the specified
-                    resource
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '401'
-                  title: Unauthorized
+                errors:
+                  - details: >-
+                      invalid authentication credentials to access the specified
+                      resource
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '401'
+                    title: Unauthorized
         '403':
           description: >-
             Forbidden to make the request. Most likely this indicates an issue
@@ -2233,26 +1595,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: access to the requested resource is forbidden
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '403'
-                  title: Forbidden
+                errors:
+                  - details: access to the requested resource is forbidden
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '403'
+                    title: Forbidden
         '404':
           description: >-
             The particular resource requested was not found. This occurs, for
@@ -2260,26 +1611,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: the resource was not found
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '404'
-                  title: Item Not Found
+                errors:
+                  - details: the resource was not found
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '404'
+                    title: Item Not Found
   /ratings/{rating_id}:
     get:
       tags:
@@ -2308,28 +1648,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: >-
-                    the request was formatted incorrectly or missing required
-                    parameters
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    parameter: status
-                  status: '400'
-                  title: Bad Request
+                errors:
+                  - details: >-
+                      the request was formatted incorrectly or missing required
+                      parameters
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      parameter: status
+                    status: '400'
+                    title: Bad Request
         '401':
           description: >-
             The request has not been fulfilled because it lacks valid
@@ -2337,28 +1666,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: >-
-                    invalid authentication credentials to access the specified
-                    resource
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '401'
-                  title: Unauthorized
+                errors:
+                  - details: >-
+                      invalid authentication credentials to access the specified
+                      resource
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '401'
+                    title: Unauthorized
         '403':
           description: >-
             Forbidden to make the request. Most likely this indicates an issue
@@ -2366,26 +1684,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: access to the requested resource is forbidden
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '403'
-                  title: Forbidden
+                errors:
+                  - details: access to the requested resource is forbidden
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '403'
+                    title: Forbidden
         '404':
           description: >-
             The particular resource requested was not found. This occurs, for
@@ -2393,26 +1700,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: the resource was not found
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '404'
-                  title: Item Not Found
+                errors:
+                  - details: the resource was not found
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '404'
+                    title: Item Not Found
   /ratings/{rating_id}/city:
     get:
       tags:
@@ -2441,28 +1737,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: >-
-                    the request was formatted incorrectly or missing required
-                    parameters
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    parameter: status
-                  status: '400'
-                  title: Bad Request
+                errors:
+                  - details: >-
+                      the request was formatted incorrectly or missing required
+                      parameters
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      parameter: status
+                    status: '400'
+                    title: Bad Request
         '401':
           description: >-
             The request has not been fulfilled because it lacks valid
@@ -2470,28 +1755,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: >-
-                    invalid authentication credentials to access the specified
-                    resource
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '401'
-                  title: Unauthorized
+                errors:
+                  - details: >-
+                      invalid authentication credentials to access the specified
+                      resource
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '401'
+                    title: Unauthorized
         '403':
           description: >-
             Forbidden to make the request. Most likely this indicates an issue
@@ -2499,26 +1773,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: access to the requested resource is forbidden
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '403'
-                  title: Forbidden
+                errors:
+                  - details: access to the requested resource is forbidden
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '403'
+                    title: Forbidden
         '404':
           description: >-
             The particular resource requested was not found. This occurs, for
@@ -2526,26 +1789,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: >-
-                  Error objects MUST be returned as an array keyed by errors in
-                  the top level of a
-
-                  JSON:API document.
-                required:
-                  - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-                - details: the resource was not found
-                  id: blfwkg8nvHcEJnQ=
-                  source:
-                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                  status: '404'
-                  title: Item Not Found
+                errors:
+                  - details: the resource was not found
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '404'
+                    title: Item Not Found
 components:
   schemas:
     APIError:
@@ -2635,6 +1887,20 @@ components:
           - parameter: a string indicating which URI query parameter caused the error.
           - header: a string indicating the name of a single request header which caused the
             error.
+    APIErrors:
+      type: object
+      description: >-
+        Error objects MUST be returned as an array keyed by errors in the top
+        level of a
+
+        JSON:API document.
+      required:
+        - errors
+      properties:
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/APIError'
     BnaPipeline:
       type: object
       required:

--- a/openapi-3.1.yaml
+++ b/openapi-3.1.yaml
@@ -69,93 +69,57 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: the request was formatted incorrectly or missing required parameters
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  parameter: status
-                status: '400'
-                title: Bad Request
+                errors:
+                - details: the request was formatted incorrectly or missing required parameters
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    parameter: status
+                  status: '400'
+                  title: Bad Request
         '401':
           description: The request has not been fulfilled because it lacks valid authentication credentials for the target resource.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: invalid authentication credentials to access the specified resource
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '401'
-                title: Unauthorized
+                errors:
+                - details: invalid authentication credentials to access the specified resource
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '401'
+                  title: Unauthorized
         '403':
           description: Forbidden to make the request. Most likely this indicates an issue with the credentials or permissions.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: access to the requested resource is forbidden
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '403'
-                title: Forbidden
+                errors:
+                - details: access to the requested resource is forbidden
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '403'
+                  title: Forbidden
         '404':
           description: The particular resource requested was not found. This occurs, for example, when the id of the requested  resource does not exist.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: the resource was not found
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '404'
-                title: Item Not Found
+                errors:
+                - details: the resource was not found
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '404'
+                  title: Item Not Found
   /cities/submissions:
     get:
       tags:
@@ -202,93 +166,57 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: the request was formatted incorrectly or missing required parameters
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  parameter: status
-                status: '400'
-                title: Bad Request
+                errors:
+                - details: the request was formatted incorrectly or missing required parameters
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    parameter: status
+                  status: '400'
+                  title: Bad Request
         '401':
           description: The request has not been fulfilled because it lacks valid authentication credentials for the target resource.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: invalid authentication credentials to access the specified resource
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '401'
-                title: Unauthorized
+                errors:
+                - details: invalid authentication credentials to access the specified resource
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '401'
+                  title: Unauthorized
         '403':
           description: Forbidden to make the request. Most likely this indicates an issue with the credentials or permissions.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: access to the requested resource is forbidden
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '403'
-                title: Forbidden
+                errors:
+                - details: access to the requested resource is forbidden
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '403'
+                  title: Forbidden
         '404':
           description: The particular resource requested was not found. This occurs, for example, when the id of the requested  resource does not exist.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: the resource was not found
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '404'
-                title: Item Not Found
+                errors:
+                - details: the resource was not found
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '404'
+                  title: Item Not Found
     post:
       tags:
       - city
@@ -312,93 +240,57 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: the request was formatted incorrectly or missing required parameters
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  parameter: status
-                status: '400'
-                title: Bad Request
+                errors:
+                - details: the request was formatted incorrectly or missing required parameters
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    parameter: status
+                  status: '400'
+                  title: Bad Request
         '401':
           description: The request has not been fulfilled because it lacks valid authentication credentials for the target resource.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: invalid authentication credentials to access the specified resource
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '401'
-                title: Unauthorized
+                errors:
+                - details: invalid authentication credentials to access the specified resource
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '401'
+                  title: Unauthorized
         '403':
           description: Forbidden to make the request. Most likely this indicates an issue with the credentials or permissions.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: access to the requested resource is forbidden
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '403'
-                title: Forbidden
+                errors:
+                - details: access to the requested resource is forbidden
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '403'
+                  title: Forbidden
         '404':
           description: The particular resource requested was not found. This occurs, for example, when the id of the requested  resource does not exist.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: the resource was not found
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '404'
-                title: Item Not Found
+                errors:
+                - details: the resource was not found
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '404'
+                  title: Item Not Found
   /cities/submissions/{submission_id}:
     get:
       tags:
@@ -433,93 +325,57 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: the request was formatted incorrectly or missing required parameters
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  parameter: status
-                status: '400'
-                title: Bad Request
+                errors:
+                - details: the request was formatted incorrectly or missing required parameters
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    parameter: status
+                  status: '400'
+                  title: Bad Request
         '401':
           description: The request has not been fulfilled because it lacks valid authentication credentials for the target resource.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: invalid authentication credentials to access the specified resource
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '401'
-                title: Unauthorized
+                errors:
+                - details: invalid authentication credentials to access the specified resource
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '401'
+                  title: Unauthorized
         '403':
           description: Forbidden to make the request. Most likely this indicates an issue with the credentials or permissions.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: access to the requested resource is forbidden
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '403'
-                title: Forbidden
+                errors:
+                - details: access to the requested resource is forbidden
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '403'
+                  title: Forbidden
         '404':
           description: The particular resource requested was not found. This occurs, for example, when the id of the requested  resource does not exist.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: the resource was not found
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '404'
-                title: Item Not Found
+                errors:
+                - details: the resource was not found
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '404'
+                  title: Item Not Found
     patch:
       tags:
       - city
@@ -552,93 +408,57 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: the request was formatted incorrectly or missing required parameters
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  parameter: status
-                status: '400'
-                title: Bad Request
+                errors:
+                - details: the request was formatted incorrectly or missing required parameters
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    parameter: status
+                  status: '400'
+                  title: Bad Request
         '401':
           description: The request has not been fulfilled because it lacks valid authentication credentials for the target resource.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: invalid authentication credentials to access the specified resource
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '401'
-                title: Unauthorized
+                errors:
+                - details: invalid authentication credentials to access the specified resource
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '401'
+                  title: Unauthorized
         '403':
           description: Forbidden to make the request. Most likely this indicates an issue with the credentials or permissions.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: access to the requested resource is forbidden
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '403'
-                title: Forbidden
+                errors:
+                - details: access to the requested resource is forbidden
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '403'
+                  title: Forbidden
         '404':
           description: The particular resource requested was not found. This occurs, for example, when the id of the requested  resource does not exist.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: the resource was not found
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '404'
-                title: Item Not Found
+                errors:
+                - details: the resource was not found
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '404'
+                  title: Item Not Found
   /cities/{country}/{region}/{name}:
     get:
       tags:
@@ -682,93 +502,57 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: the request was formatted incorrectly or missing required parameters
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  parameter: status
-                status: '400'
-                title: Bad Request
+                errors:
+                - details: the request was formatted incorrectly or missing required parameters
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    parameter: status
+                  status: '400'
+                  title: Bad Request
         '401':
           description: The request has not been fulfilled because it lacks valid authentication credentials for the target resource.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: invalid authentication credentials to access the specified resource
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '401'
-                title: Unauthorized
+                errors:
+                - details: invalid authentication credentials to access the specified resource
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '401'
+                  title: Unauthorized
         '403':
           description: Forbidden to make the request. Most likely this indicates an issue with the credentials or permissions.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: access to the requested resource is forbidden
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '403'
-                title: Forbidden
+                errors:
+                - details: access to the requested resource is forbidden
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '403'
+                  title: Forbidden
         '404':
           description: The particular resource requested was not found. This occurs, for example, when the id of the requested  resource does not exist.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: the resource was not found
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '404'
-                title: Item Not Found
+                errors:
+                - details: the resource was not found
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '404'
+                  title: Item Not Found
   /cities/{country}/{region}/{name}/census:
     get:
       tags:
@@ -832,93 +616,57 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: the request was formatted incorrectly or missing required parameters
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  parameter: status
-                status: '400'
-                title: Bad Request
+                errors:
+                - details: the request was formatted incorrectly or missing required parameters
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    parameter: status
+                  status: '400'
+                  title: Bad Request
         '401':
           description: The request has not been fulfilled because it lacks valid authentication credentials for the target resource.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: invalid authentication credentials to access the specified resource
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '401'
-                title: Unauthorized
+                errors:
+                - details: invalid authentication credentials to access the specified resource
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '401'
+                  title: Unauthorized
         '403':
           description: Forbidden to make the request. Most likely this indicates an issue with the credentials or permissions.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: access to the requested resource is forbidden
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '403'
-                title: Forbidden
+                errors:
+                - details: access to the requested resource is forbidden
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '403'
+                  title: Forbidden
         '404':
           description: The particular resource requested was not found. This occurs, for example, when the id of the requested  resource does not exist.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: the resource was not found
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '404'
-                title: Item Not Found
+                errors:
+                - details: the resource was not found
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '404'
+                  title: Item Not Found
     post:
       tags:
       - city
@@ -967,93 +715,57 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: the request was formatted incorrectly or missing required parameters
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  parameter: status
-                status: '400'
-                title: Bad Request
+                errors:
+                - details: the request was formatted incorrectly or missing required parameters
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    parameter: status
+                  status: '400'
+                  title: Bad Request
         '401':
           description: The request has not been fulfilled because it lacks valid authentication credentials for the target resource.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: invalid authentication credentials to access the specified resource
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '401'
-                title: Unauthorized
+                errors:
+                - details: invalid authentication credentials to access the specified resource
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '401'
+                  title: Unauthorized
         '403':
           description: Forbidden to make the request. Most likely this indicates an issue with the credentials or permissions.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: access to the requested resource is forbidden
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '403'
-                title: Forbidden
+                errors:
+                - details: access to the requested resource is forbidden
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '403'
+                  title: Forbidden
         '404':
           description: The particular resource requested was not found. This occurs, for example, when the id of the requested  resource does not exist.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: the resource was not found
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '404'
-                title: Item Not Found
+                errors:
+                - details: the resource was not found
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '404'
+                  title: Item Not Found
   /cities/{country}/{region}/{name}/ratings:
     get:
       tags:
@@ -1117,93 +829,57 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: the request was formatted incorrectly or missing required parameters
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  parameter: status
-                status: '400'
-                title: Bad Request
+                errors:
+                - details: the request was formatted incorrectly or missing required parameters
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    parameter: status
+                  status: '400'
+                  title: Bad Request
         '401':
           description: The request has not been fulfilled because it lacks valid authentication credentials for the target resource.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: invalid authentication credentials to access the specified resource
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '401'
-                title: Unauthorized
+                errors:
+                - details: invalid authentication credentials to access the specified resource
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '401'
+                  title: Unauthorized
         '403':
           description: Forbidden to make the request. Most likely this indicates an issue with the credentials or permissions.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: access to the requested resource is forbidden
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '403'
-                title: Forbidden
+                errors:
+                - details: access to the requested resource is forbidden
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '403'
+                  title: Forbidden
         '404':
           description: The particular resource requested was not found. This occurs, for example, when the id of the requested  resource does not exist.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: the resource was not found
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '404'
-                title: Item Not Found
+                errors:
+                - details: the resource was not found
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '404'
+                  title: Item Not Found
   /pipelines/bna:
     get:
       tags:
@@ -1243,93 +919,57 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: the request was formatted incorrectly or missing required parameters
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  parameter: status
-                status: '400'
-                title: Bad Request
+                errors:
+                - details: the request was formatted incorrectly or missing required parameters
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    parameter: status
+                  status: '400'
+                  title: Bad Request
         '401':
           description: The request has not been fulfilled because it lacks valid authentication credentials for the target resource.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: invalid authentication credentials to access the specified resource
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '401'
-                title: Unauthorized
+                errors:
+                - details: invalid authentication credentials to access the specified resource
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '401'
+                  title: Unauthorized
         '403':
           description: Forbidden to make the request. Most likely this indicates an issue with the credentials or permissions.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: access to the requested resource is forbidden
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '403'
-                title: Forbidden
+                errors:
+                - details: access to the requested resource is forbidden
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '403'
+                  title: Forbidden
         '404':
           description: The particular resource requested was not found. This occurs, for example, when the id of the requested  resource does not exist.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: the resource was not found
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '404'
-                title: Item Not Found
+                errors:
+                - details: the resource was not found
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '404'
+                  title: Item Not Found
     post:
       tags:
       - pipeline
@@ -1353,93 +993,57 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: the request was formatted incorrectly or missing required parameters
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  parameter: status
-                status: '400'
-                title: Bad Request
+                errors:
+                - details: the request was formatted incorrectly or missing required parameters
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    parameter: status
+                  status: '400'
+                  title: Bad Request
         '401':
           description: The request has not been fulfilled because it lacks valid authentication credentials for the target resource.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: invalid authentication credentials to access the specified resource
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '401'
-                title: Unauthorized
+                errors:
+                - details: invalid authentication credentials to access the specified resource
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '401'
+                  title: Unauthorized
         '403':
           description: Forbidden to make the request. Most likely this indicates an issue with the credentials or permissions.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: access to the requested resource is forbidden
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '403'
-                title: Forbidden
+                errors:
+                - details: access to the requested resource is forbidden
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '403'
+                  title: Forbidden
         '404':
           description: The particular resource requested was not found. This occurs, for example, when the id of the requested  resource does not exist.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: the resource was not found
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '404'
-                title: Item Not Found
+                errors:
+                - details: the resource was not found
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '404'
+                  title: Item Not Found
   /pipelines/bna/{pipeline_id}:
     get:
       tags:
@@ -1466,93 +1070,57 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: the request was formatted incorrectly or missing required parameters
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  parameter: status
-                status: '400'
-                title: Bad Request
+                errors:
+                - details: the request was formatted incorrectly or missing required parameters
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    parameter: status
+                  status: '400'
+                  title: Bad Request
         '401':
           description: The request has not been fulfilled because it lacks valid authentication credentials for the target resource.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: invalid authentication credentials to access the specified resource
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '401'
-                title: Unauthorized
+                errors:
+                - details: invalid authentication credentials to access the specified resource
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '401'
+                  title: Unauthorized
         '403':
           description: Forbidden to make the request. Most likely this indicates an issue with the credentials or permissions.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: access to the requested resource is forbidden
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '403'
-                title: Forbidden
+                errors:
+                - details: access to the requested resource is forbidden
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '403'
+                  title: Forbidden
         '404':
           description: The particular resource requested was not found. This occurs, for example, when the id of the requested  resource does not exist.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: the resource was not found
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '404'
-                title: Item Not Found
+                errors:
+                - details: the resource was not found
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '404'
+                  title: Item Not Found
     patch:
       tags:
       - pipeline
@@ -1584,93 +1152,57 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: the request was formatted incorrectly or missing required parameters
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  parameter: status
-                status: '400'
-                title: Bad Request
+                errors:
+                - details: the request was formatted incorrectly or missing required parameters
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    parameter: status
+                  status: '400'
+                  title: Bad Request
         '401':
           description: The request has not been fulfilled because it lacks valid authentication credentials for the target resource.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: invalid authentication credentials to access the specified resource
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '401'
-                title: Unauthorized
+                errors:
+                - details: invalid authentication credentials to access the specified resource
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '401'
+                  title: Unauthorized
         '403':
           description: Forbidden to make the request. Most likely this indicates an issue with the credentials or permissions.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: access to the requested resource is forbidden
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '403'
-                title: Forbidden
+                errors:
+                - details: access to the requested resource is forbidden
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '403'
+                  title: Forbidden
         '404':
           description: The particular resource requested was not found. This occurs, for example, when the id of the requested  resource does not exist.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: the resource was not found
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '404'
-                title: Item Not Found
+                errors:
+                - details: the resource was not found
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '404'
+                  title: Item Not Found
   /prices/fargate:
     get:
       tags:
@@ -1731,93 +1263,57 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: the request was formatted incorrectly or missing required parameters
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  parameter: status
-                status: '400'
-                title: Bad Request
+                errors:
+                - details: the request was formatted incorrectly or missing required parameters
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    parameter: status
+                  status: '400'
+                  title: Bad Request
         '401':
           description: The request has not been fulfilled because it lacks valid authentication credentials for the target resource.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: invalid authentication credentials to access the specified resource
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '401'
-                title: Unauthorized
+                errors:
+                - details: invalid authentication credentials to access the specified resource
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '401'
+                  title: Unauthorized
         '403':
           description: Forbidden to make the request. Most likely this indicates an issue with the credentials or permissions.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: access to the requested resource is forbidden
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '403'
-                title: Forbidden
+                errors:
+                - details: access to the requested resource is forbidden
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '403'
+                  title: Forbidden
         '404':
           description: The particular resource requested was not found. This occurs, for example, when the id of the requested  resource does not exist.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: the resource was not found
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '404'
-                title: Item Not Found
+                errors:
+                - details: the resource was not found
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '404'
+                  title: Item Not Found
   /ratings:
     get:
       tags:
@@ -1875,93 +1371,57 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: the request was formatted incorrectly or missing required parameters
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  parameter: status
-                status: '400'
-                title: Bad Request
+                errors:
+                - details: the request was formatted incorrectly or missing required parameters
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    parameter: status
+                  status: '400'
+                  title: Bad Request
         '401':
           description: The request has not been fulfilled because it lacks valid authentication credentials for the target resource.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: invalid authentication credentials to access the specified resource
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '401'
-                title: Unauthorized
+                errors:
+                - details: invalid authentication credentials to access the specified resource
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '401'
+                  title: Unauthorized
         '403':
           description: Forbidden to make the request. Most likely this indicates an issue with the credentials or permissions.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: access to the requested resource is forbidden
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '403'
-                title: Forbidden
+                errors:
+                - details: access to the requested resource is forbidden
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '403'
+                  title: Forbidden
         '404':
           description: The particular resource requested was not found. This occurs, for example, when the id of the requested  resource does not exist.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: the resource was not found
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '404'
-                title: Item Not Found
+                errors:
+                - details: the resource was not found
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '404'
+                  title: Item Not Found
   /ratings/{rating_id}:
     get:
       tags:
@@ -1988,93 +1448,57 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: the request was formatted incorrectly or missing required parameters
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  parameter: status
-                status: '400'
-                title: Bad Request
+                errors:
+                - details: the request was formatted incorrectly or missing required parameters
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    parameter: status
+                  status: '400'
+                  title: Bad Request
         '401':
           description: The request has not been fulfilled because it lacks valid authentication credentials for the target resource.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: invalid authentication credentials to access the specified resource
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '401'
-                title: Unauthorized
+                errors:
+                - details: invalid authentication credentials to access the specified resource
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '401'
+                  title: Unauthorized
         '403':
           description: Forbidden to make the request. Most likely this indicates an issue with the credentials or permissions.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: access to the requested resource is forbidden
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '403'
-                title: Forbidden
+                errors:
+                - details: access to the requested resource is forbidden
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '403'
+                  title: Forbidden
         '404':
           description: The particular resource requested was not found. This occurs, for example, when the id of the requested  resource does not exist.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: the resource was not found
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '404'
-                title: Item Not Found
+                errors:
+                - details: the resource was not found
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '404'
+                  title: Item Not Found
   /ratings/{rating_id}/city:
     get:
       tags:
@@ -2101,93 +1525,57 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: the request was formatted incorrectly or missing required parameters
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  parameter: status
-                status: '400'
-                title: Bad Request
+                errors:
+                - details: the request was formatted incorrectly or missing required parameters
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    parameter: status
+                  status: '400'
+                  title: Bad Request
         '401':
           description: The request has not been fulfilled because it lacks valid authentication credentials for the target resource.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: invalid authentication credentials to access the specified resource
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '401'
-                title: Unauthorized
+                errors:
+                - details: invalid authentication credentials to access the specified resource
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '401'
+                  title: Unauthorized
         '403':
           description: Forbidden to make the request. Most likely this indicates an issue with the credentials or permissions.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: access to the requested resource is forbidden
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '403'
-                title: Forbidden
+                errors:
+                - details: access to the requested resource is forbidden
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '403'
+                  title: Forbidden
         '404':
           description: The particular resource requested was not found. This occurs, for example, when the id of the requested  resource does not exist.
           content:
             application/json:
               schema:
-                type: object
-                description: |-
-                  Error objects MUST be returned as an array keyed by errors in the top level of a
-                  JSON:API document.
-                required:
-                - errors
-                properties:
-                  errors:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/APIError'
+                $ref: '#/components/schemas/APIErrors'
               example:
-              - details: the resource was not found
-                id: blfwkg8nvHcEJnQ=
-                source:
-                  pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
-                status: '404'
-                title: Item Not Found
+                errors:
+                - details: the resource was not found
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '404'
+                  title: Item Not Found
 components:
   schemas:
     APIError:
@@ -2274,6 +1662,18 @@ components:
           - parameter: a string indicating which URI query parameter caused the error.
           - header: a string indicating the name of a single request header which caused the
             error.
+    APIErrors:
+      type: object
+      description: |-
+        Error objects MUST be returned as an array keyed by errors in the top level of a
+        JSON:API document.
+      required:
+      - errors
+      properties:
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/APIError'
     BnaPipeline:
       type: object
       required:


### PR DESCRIPTION
Ensures the ApiErrors struct is imported correctly, and then referenced
in the reposonses instead on inlined.

Updates the bnaclient accordingly.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
