### PR TITLE
Migrate to Axum 8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,14 +760,14 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.9"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+checksum = "6d6fd624c75e18b3b4c6b9caf42b1afe24437daaee904069137d8bab077be8b8"
 dependencies = [
- "async-trait",
- "axum-core 0.4.5",
+ "axum-core",
  "axum-macros",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http 1.2.0",
  "http-body 1.0.1",
@@ -775,7 +775,7 @@ dependencies = [
  "hyper 1.5.2",
  "hyper-util",
  "itoa",
- "matchit 0.7.3",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -788,55 +788,6 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tower 0.5.2",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d6fd624c75e18b3b4c6b9caf42b1afe24437daaee904069137d8bab077be8b8"
-dependencies = [
- "axum-core 0.5.0",
- "bytes",
- "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
- "http-body-util",
- "itoa",
- "matchit 0.8.4",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "sync_wrapper",
- "tower 0.5.2",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -859,27 +810,28 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
 name = "axum-extra"
-version = "0.9.6"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c794b30c904f0a1c2fb7740f7df7f7972dfaa14ef6f57cb6178dc63e5dca2f04"
+checksum = "460fc6f625a1f7705c6cf62d0d070794e94668988b1c38111baeec177c715f7b"
 dependencies = [
- "axum 0.7.9",
- "axum-core 0.4.5",
+ "axum",
+ "axum-core",
  "bytes",
- "fastrand",
+ "form_urlencoded",
  "futures-util",
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
- "multer",
  "pin-project-lite",
  "serde",
  "serde_html_form",
+ "serde_path_to_error",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
@@ -887,9 +839,9 @@ dependencies = [
 
 [[package]]
 name = "axum-macros"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
+checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -898,11 +850,11 @@ dependencies = [
 
 [[package]]
 name = "axum-streams"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef49936ad8fd9750be8bb5c75f64b19bd407027c5c9e89c42e0939122d162d67"
+checksum = "7e706938a2f02ac53dac79575d99819fa6285a5eae35b0fa27b959affb80c435"
 dependencies = [
- "axum 0.7.9",
+ "axum",
  "bytes",
  "csv",
  "futures",
@@ -2710,7 +2662,7 @@ dependencies = [
  "aws-sdk-s3",
  "aws-sdk-sqs",
  "aws_lambda_events",
- "axum 0.7.9",
+ "axum",
  "axum-extra",
  "axum-streams",
  "bnacore",
@@ -2888,12 +2840,6 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
-name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
@@ -2989,23 +2935,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "multer"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
-dependencies = [
- "bytes",
- "encoding_rs",
- "futures-util",
- "http 1.2.0",
- "httparse",
- "memchr",
- "mime",
- "spin",
- "version_check",
 ]
 
 [[package]]
@@ -5419,7 +5348,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff0d605008ed085986e1803fd5c81d18c0f8503b1e4bbb21ea75b3fc20dd1efb"
 dependencies = [
- "axum 0.8.1",
+ "axum",
  "paste",
  "tower-layer",
  "tower-service",
@@ -5444,7 +5373,7 @@ version = "8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "040cad8bd8de63f3d028e08e5b39be49d68f8a646e99f4aea2e2d4d82c34b21f"
 dependencies = [
- "axum 0.8.1",
+ "axum",
  "base64 0.22.1",
  "mime_guess",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ aws_lambda_events = "0.16.0"
 aws-config = "1.5.13"
 aws-sdk-s3 = "1.68.0"
 aws-sdk-sqs = "1.53.0"
-axum = "0.7.7"
-axum-extra = "0.9.4"
-axum-streams = "0.19.0"
+axum = "0.8.1"
+axum-extra = "0.10.0"
+axum-streams = "0.20.0"
 bnacore = { git = "https://github.com/PeopleForBikes/brokenspoke", rev = "c20ec31" }
 bon = "3.0.1"
 chrono = "0.4.24"
@@ -56,8 +56,8 @@ utoipa-swagger-ui = "8.1.1"
 uuid = "1.11.1"
 
 [dependencies]
-chrono = { workspace = true }
 color-eyre = { workspace = true }
+chrono = { workspace = true }
 dotenv = { workspace = true }
 entity = { workspace = true }
 futures = { workspace = true }

--- a/effortless/src/api.rs
+++ b/effortless/src/api.rs
@@ -195,16 +195,16 @@ pub const DEFAULT_PAGE_SIZE: u64 = 50;
 #[derive(Debug, Deserialize)]
 pub struct PaginationParameters {
     /// The number of items per page.
-    pub page_size: Option<u64>,
+    page_size: Option<u64>,
     /// The result page being returned.
-    pub page: u64,
+    page: Option<u64>,
 }
 
 impl Default for PaginationParameters {
     fn default() -> Self {
         Self {
             page_size: Some(DEFAULT_PAGE_SIZE),
-            page: 0,
+            page: Some(0),
         }
     }
 }
@@ -220,6 +220,10 @@ impl PaginationParameters {
             },
             None => DEFAULT_PAGE_SIZE,
         }
+    }
+
+    pub fn page(&self) -> u64 {
+        self.page.unwrap_or_default()
     }
 }
 
@@ -263,7 +267,7 @@ pub fn extract_pagination_parameters(
     let parameter = "page";
     if let Some(page) = event.query_string_parameters().first(parameter) {
         match page.parse::<u64>() {
-            Ok(page) => pagination.page = page,
+            Ok(page) => pagination.page = Some(page),
             Err(e) => {
                 let api_error = invalid_query_parameter(
                     event,
@@ -295,8 +299,8 @@ mod tests {
         let req = from_str(input).unwrap();
 
         let actual = extract_pagination_parameters(&req).unwrap();
-        assert_eq!(actual.page_size, Some(DEFAULT_PAGE_SIZE));
-        assert_eq!(actual.page, 0);
+        assert_eq!(actual.page_size(), DEFAULT_PAGE_SIZE);
+        assert_eq!(actual.page(), 0);
     }
 
     #[test]
@@ -313,8 +317,8 @@ mod tests {
         let req = result.with_query_string_parameters(data);
 
         let actual = extract_pagination_parameters(&req).unwrap();
-        assert_eq!(actual.page_size, Some(PAGE_SIZE));
-        assert_eq!(actual.page, PAGE);
+        assert_eq!(actual.page_size(), PAGE_SIZE);
+        assert_eq!(actual.page(), PAGE);
     }
 
     #[test]

--- a/lambdas/src/core/resource/cities/endpoint.rs
+++ b/lambdas/src/core/resource/cities/endpoint.rs
@@ -68,6 +68,7 @@ async fn get_city(
         .map(Json)
 }
 
+#[axum::debug_handler]
 #[utoipa::path(
   get,
   path = "/cities",
@@ -80,12 +81,12 @@ async fn get_city(
     (status = OK, description = "Fetches cities", body = Cities),
   ))]
 async fn get_cities(
-    pagination: Option<Query<PaginationParameters>>,
+    Query(pagination): Query<PaginationParameters>,
 ) -> Result<PageFlow<Cities>, ExecutionError> {
-    let Query(pagination) = pagination.unwrap_or_default();
-    let payload = get_cities_adaptor(pagination.page, pagination.page_size()).await?;
+    // let Query(pagination) = pagination;
+    let payload = get_cities_adaptor(pagination.page(), pagination.page_size()).await?;
     Ok(PageFlow::new(
-        Paginatron::new(None, payload.0, pagination.page, pagination.page_size()),
+        Paginatron::new(None, payload.0, pagination.page(), pagination.page_size()),
         payload.1.into(),
     ))
 }
@@ -105,14 +106,14 @@ async fn get_cities(
   ))]
 async fn get_city_censuses(
     Path(params): Path<CitiesPathParameters>,
-    pagination: Option<Query<PaginationParameters>>,
+    Query(pagination): Query<PaginationParameters>,
 ) -> Result<PageFlow<CityCensuses>, ExecutionError> {
-    let Query(pagination) = pagination.unwrap_or_default();
+    // let Query(pagination) = pagination.unwrap_or_default();
     let city_censuses = get_cities_censuses_adaptor(
         &params.country,
         &params.region,
         &params.name,
-        pagination.page,
+        pagination.page(),
         pagination.page_size(),
     )
     .await?;
@@ -132,7 +133,7 @@ async fn get_city_censuses(
         Paginatron::new(
             None,
             city_censuses.0,
-            pagination.page,
+            pagination.page(),
             pagination.page_size(),
         ),
         payload,
@@ -154,15 +155,14 @@ async fn get_city_censuses(
   ))]
 async fn get_city_ratings(
     Path(params): Path<CitiesPathParameters>,
-    pagination: Option<Query<PaginationParameters>>,
+    Query(pagination): Query<PaginationParameters>,
     ctx: Context,
 ) -> Result<PageFlow<CityRatings>, ExecutionError> {
-    let Query(pagination) = pagination.unwrap_or_default();
     let city_ratings = get_cities_ratings_adaptor(
         &params.country,
         &params.region,
         &params.name,
-        pagination.page,
+        pagination.page(),
         pagination.page_size(),
         ctx,
     )
@@ -182,7 +182,7 @@ async fn get_city_ratings(
         Paginatron::new(
             None,
             city_ratings.0,
-            pagination.page,
+            pagination.page(),
             pagination.page_size(),
         ),
         payload,
@@ -247,12 +247,11 @@ struct SubmissionParameters {
     ))]
 async fn get_cities_submissions(
     Query(submission_params): Query<SubmissionParameters>,
-    pagination: Option<Query<PaginationParameters>>,
+    Query(pagination): Query<PaginationParameters>,
 ) -> Result<PageFlow<Submissions>, ExecutionError> {
-    let Query(pagination) = pagination.unwrap_or_default();
     let cities_submissions = get_cities_submissions_adaptor(
         submission_params.status,
-        pagination.page,
+        pagination.page(),
         pagination.page_size(),
     )
     .await?;
@@ -267,7 +266,7 @@ async fn get_cities_submissions(
         Paginatron::new(
             None,
             cities_submissions.0,
-            pagination.page,
+            pagination.page(),
             pagination.page_size(),
         ),
         payload,

--- a/lambdas/src/core/resource/pipelines/endpoint.rs
+++ b/lambdas/src/core/resource/pipelines/endpoint.rs
@@ -64,10 +64,9 @@ async fn get_pipelines_bna(
     ErrorResponses,
   ))]
 async fn get_pipelines_bnas(
-    pagination: Option<Query<PaginationParameters>>,
+    Query(pagination): Query<PaginationParameters>,
 ) -> Result<Json<Value>, ExecutionError> {
-    let Query(pagination) = pagination.unwrap_or_default();
-    get_pipelines_bnas_adaptor(pagination.page, pagination.page_size())
+    get_pipelines_bnas_adaptor(pagination.page(), pagination.page_size())
         .await
         .map(|v| Json(json!(v.payload())))
 }

--- a/lambdas/src/core/resource/price/endpoint.rs
+++ b/lambdas/src/core/resource/price/endpoint.rs
@@ -37,19 +37,18 @@ pub fn routes() -> OpenApiRouter {
     (status = OK, description = "Fetches a collection of Fargate prices", body = FargatePrices),
   ))]
 pub(crate) async fn get_prices_fargate(
-    pagination: Option<Query<PaginationParameters>>,
+    Query(pagination): Query<PaginationParameters>,
     price_parameters: PriceParameters,
 ) -> Result<PageFlow<FargatePrices>, ExecutionError> {
-    let Query(pagination) = pagination.unwrap_or_default();
     let (total_items, models) = get_prices_fargate_adaptor_model_(
         price_parameters,
-        pagination.page,
+        pagination.page(),
         pagination.page_size(),
     )
     .await?;
     let payload: FargatePrices = models.into();
     Ok(PageFlow::new(
-        Paginatron::new(None, total_items, pagination.page, pagination.page_size()),
+        Paginatron::new(None, total_items, pagination.page(), pagination.page_size()),
         payload,
     ))
 }

--- a/lambdas/src/core/resource/price/mod.rs
+++ b/lambdas/src/core/resource/price/mod.rs
@@ -1,6 +1,5 @@
 use crate::Sort;
 use axum::{
-    async_trait,
     extract::FromRequestParts,
     http::{request::Parts, StatusCode},
 };
@@ -39,7 +38,6 @@ impl Default for PriceParameters {
     }
 }
 
-#[async_trait]
 impl<S> FromRequestParts<S> for PriceParameters
 where
     S: Send + Sync,

--- a/lambdas/src/core/resource/ratings/endpoint.rs
+++ b/lambdas/src/core/resource/ratings/endpoint.rs
@@ -67,15 +67,14 @@ async fn get_rating(
     (status = OK, description = "Fetches the city ratings", body = Ratings),
   ))]
 async fn get_ratings(
-    pagination: Option<Query<PaginationParameters>>,
+    Query(pagination): Query<PaginationParameters>,
 ) -> Result<PageFlow<Ratings>, ExecutionError> {
-    let Query(pagination) = pagination.unwrap_or_default();
     let (total_items, models) =
-        get_ratings_adaptor(pagination.page, pagination.page_size()).await?;
+        get_ratings_adaptor(pagination.page(), pagination.page_size()).await?;
 
     let payload: Ratings = models.into();
     Ok(PageFlow::new(
-        Paginatron::new(None, total_items, pagination.page, pagination.page_size()),
+        Paginatron::new(None, total_items, pagination.page(), pagination.page_size()),
         payload,
     ))
 }

--- a/lambdas/src/lib.rs
+++ b/lambdas/src/lib.rs
@@ -1,7 +1,6 @@
 pub mod core;
 
 use axum::{
-    async_trait,
     extract::{FromRequest, OriginalUri},
     response::IntoResponse,
 };
@@ -399,7 +398,6 @@ pub struct Context {
     source: String,
 }
 
-#[async_trait]
 impl<S> FromRequest<S> for Context
 where
     S: Send + Sync,

--- a/lambdas/tests/localhost.vars
+++ b/lambdas/tests/localhost.vars
@@ -1,6 +1,7 @@
 host=http://localhost:3000
 rating_id=1a759b85-cd87-4bb1-9efa-5789e38e9982
-max_page_size=50
+max_page_size=100
+default_page_size=50
 country=United%20States
 region=Texas
 name=Austin

--- a/lambdas/tests/scenario/pagination.hurl
+++ b/lambdas/tests/scenario/pagination.hurl
@@ -6,10 +6,10 @@ GET {{host}}/ratings
 
 HTTP 200
 [Asserts]
-header "X-Per-Page" == "{{max_page_size}}"
+header "X-Per-Page" == "{{default_page_size}}"
 header "X-page" == "0"
 
-# Queries a the first page of the BNA with a page_size too big.
+# Queries the first page of the BNA with a page_size too big.
 # Ensures at most MAX_PAGE_SIZE is returned.
 GET {{host}}/ratings?page_size=150
 
@@ -22,9 +22,7 @@ jsonpath "$" count <= {{max_page_size}}
 # Should return the first page of results.
 GET {{host}}/ratings?page=-5
 
-HTTP 200
-[Asserts]
-header "X-page" == "0"
+HTTP 400
 
 # Queries the BNA with a valid page number but which does not exist.
 # Should return the last page of results.
@@ -42,5 +40,5 @@ GET {{host}}/cities
 
 HTTP 200
 [Asserts]
-header "X-Per-Page" == "{{max_page_size}}"
+header "X-Per-Page" == "{{default_page_size}}"
 header "X-page" == "0"

--- a/lambdas/tests/smoke/public-readonly.hurl
+++ b/lambdas/tests/smoke/public-readonly.hurl
@@ -76,3 +76,8 @@ GET {{host}}/prices/fargate?latest=true
 HTTP 200
 [Asserts]
 jsonpath "$" count == 1
+
+# Fetch 2024 city reports.
+GET {{host}}/reports/2024
+
+HTTP 200

--- a/lambdas/tests/staging.vars
+++ b/lambdas/tests/staging.vars
@@ -1,6 +1,7 @@
 host=https://api.peopleforbikes.xyz
 rating_id=1a759b85-cd87-4bb1-9efa-5789e38e9982
 max_page_size=100
+default_page_size=50
 country=United%20States
 region=Texas
 name=Austin


### PR DESCRIPTION
Migrates the API to Axum 8.

The integration tests have been updated accordingly.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
