### PR TITLE
Add progenitor-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1004,7 +1004,7 @@ dependencies = [
  "bytes",
  "chrono",
  "futures-core",
- "percent-encoding",
+ "progenitor-client",
  "reqwest",
  "serde",
  "serde_json",
@@ -3368,6 +3368,21 @@ dependencies = [
  "syn 2.0.93",
  "version_check",
  "yansi",
+]
+
+[[package]]
+name = "progenitor-client"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdae8df95f0b2a7d6159a9c43b7380016b8d3b0fc1ece46871ecd2e0087cfaf6"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "percent-encoding",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
 ]
 
 [[package]]

--- a/bnaclient/Cargo.toml
+++ b/bnaclient/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 bytes = "1.0"
 chrono = { workspace = true, features = ["serde"] }
 futures-core = "0.3"
-percent-encoding = "2.3"
+progenitor-client = "0.9.1"
 reqwest = { workspace = true, features = ["json", "stream"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }


### PR DESCRIPTION
Adds the progenitor client to the bnaclient dependencies.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
