### PR TITLE
Fix POST /ratings

### DIFF
--- a/bnaclient/src/lib.rs
+++ b/bnaclient/src/lib.rs
@@ -2237,6 +2237,7 @@ pub mod types {
     ///    "people",
     ///    "recreation",
     ///    "retail",
+    ///    "score",
     ///    "transit",
     ///    "version"
     ///  ],
@@ -2264,6 +2265,11 @@ pub mod types {
     ///    "retail": {
     ///      "$ref": "#/components/schemas/Retail"
     ///    },
+    ///    "score": {
+    ///      "description": "City rating score",
+    ///      "type": "number",
+    ///      "format": "double"
+    ///    },
     ///    "transit": {
     ///      "$ref": "#/components/schemas/Transit"
     ///    },
@@ -2285,6 +2291,7 @@ pub mod types {
         pub people: People,
         pub recreation: Recreation,
         pub retail: Retail,
+        pub score: f64,
         pub transit: Transit,
         ///Rating version
         ///The format follows the [calver](https://calver.org) specification with
@@ -5134,6 +5141,7 @@ pub mod types {
             people: ::std::result::Result<super::People, ::std::string::String>,
             recreation: ::std::result::Result<super::Recreation, ::std::string::String>,
             retail: ::std::result::Result<super::Retail, ::std::string::String>,
+            score: ::std::result::Result<f64, ::std::string::String>,
             transit: ::std::result::Result<super::Transit, ::std::string::String>,
             version: ::std::result::Result<::std::string::String, ::std::string::String>,
         }
@@ -5148,6 +5156,7 @@ pub mod types {
                     people: Err("no value supplied for people".to_string()),
                     recreation: Err("no value supplied for recreation".to_string()),
                     retail: Err("no value supplied for retail".to_string()),
+                    score: Err("no value supplied for score".to_string()),
                     transit: Err("no value supplied for transit".to_string()),
                     version: Err("no value supplied for version".to_string()),
                 }
@@ -5225,6 +5234,16 @@ pub mod types {
                     .map_err(|e| format!("error converting supplied value for retail: {}", e));
                 self
             }
+            pub fn score<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<f64>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.score = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for score: {}", e));
+                self
+            }
             pub fn transit<T>(mut self, value: T) -> Self
             where
                 T: ::std::convert::TryInto<super::Transit>,
@@ -5260,6 +5279,7 @@ pub mod types {
                     people: value.people?,
                     recreation: value.recreation?,
                     retail: value.retail?,
+                    score: value.score?,
                     transit: value.transit?,
                     version: value.version?,
                 })
@@ -5276,6 +5296,7 @@ pub mod types {
                     people: Ok(value.people),
                     recreation: Ok(value.recreation),
                     retail: Ok(value.retail),
+                    score: Ok(value.score),
                     transit: Ok(value.transit),
                     version: Ok(value.version),
                 }

--- a/lambdas/requests.rest
+++ b/lambdas/requests.rest
@@ -208,6 +208,7 @@ content-type: application/json
 Authorization: Bearer {{cognito_access}}
 
 {
+  "city_id": "09c049b6-213b-405c-bc4e-178346ff814d",
   "core_services": {
     "dentists": 0,
     "doctors": 0,
@@ -228,27 +229,24 @@ Authorization: Bearer {{cognito_access}}
     "technical_vocational_college": 0
   },
   "people": {
-    "score": 19.17
+    "people": 19.17
   },
   "recreation": {
     "community_centers": 0,
     "parks": 7.13,
-    "recreation_trails": 0,
-    "score": 7.13
+    "score": 7.13,
+    "trails": 0
   },
   "retail": {
-    "score": 0
-  },
-  "summary": {
-    "city_id": "aac22433-37d4-4cb7-b6b8-e7e77cbbcf41",
-    "rating_id": "7b80ac57-f32e-44db-8442-e9cbf449b306",
-    "score": 0,
-    "version": "24.12"
+    "retail": 0
   },
   "transit": {
-    "score": 0
-  }
+    "transit": 0
+  },
+  "version": "24.12",
+  "score": 8.93
 }
+
 ### Create a new city.
 POST {{host}}/cities/
 content-type: application/json

--- a/lambdas/src/core/resource/ratings/endpoint.rs
+++ b/lambdas/src/core/resource/ratings/endpoint.rs
@@ -14,7 +14,6 @@ use axum::{
     Json,
 };
 use effortless::api::PaginationParameters;
-use entity::wrappers::bna::BNAPost;
 use tracing::debug;
 use utoipa_axum::{router::OpenApiRouter, routes};
 use uuid::Uuid;
@@ -90,7 +89,7 @@ async fn get_ratings(
     ErrorResponses,
   ))]
 async fn post_rating(
-    Json(bna): Json<BNAPost>,
+    Json(bna): Json<RatingPost>,
 ) -> Result<(StatusCode, Json<Rating>), ExecutionError> {
     post_ratings_adaptor(bna)
         .await

--- a/lambdas/src/core/resource/ratings/schema.rs
+++ b/lambdas/src/core/resource/ratings/schema.rs
@@ -1,11 +1,11 @@
 //! Describes the Ratings schemas.
 use super::db::Bna;
 use crate::core::resource::schema::City;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-#[derive(ToSchema, Serialize)]
+#[derive(ToSchema, Serialize, Deserialize)]
 pub(crate) struct Rating {
     // BNA Summary
     /// Rating identifier
@@ -88,98 +88,98 @@ impl From<Bna> for Rating {
     }
 }
 
-#[derive(ToSchema, Serialize)]
+#[derive(ToSchema, Serialize, Deserialize)]
 pub(crate) struct Infrastructure {
     /// Total miles of low-stress streets and paths in the measured area.
     #[schema(examples(127))]
-    low_stress_miles: Option<f64>,
+    pub(crate) low_stress_miles: Option<f64>,
     /// Total miles of high-stress streets in the measured area.
     #[schema(examples(253))]
-    high_stress_miles: Option<f64>,
+    pub(crate) high_stress_miles: Option<f64>,
 }
 
-#[derive(ToSchema, Serialize)]
+#[derive(ToSchema, Serialize, Deserialize)]
 pub(crate) struct Recreation {
     /// BNA category subscore for access to community centers.
     #[schema(minimum = 0, maximum = 100)]
-    community_centers: Option<f64>,
+    pub(crate) community_centers: Option<f64>,
     /// BNA category subscore for access to parks.
     #[schema(minimum = 0, maximum = 100)]
-    parks: Option<f64>,
+    pub(crate) parks: Option<f64>,
     /// BNA category subscore for access to bikeable trails.
     #[schema(minimum = 0, maximum = 100)]
-    trails: Option<f64>,
+    pub(crate) trails: Option<f64>,
     /// BNA category score for access to recreational facilities.
     #[schema(minimum = 0, maximum = 100)]
-    score: Option<f64>,
+    pub(crate) score: Option<f64>,
 }
 
-#[derive(ToSchema, Serialize)]
+#[derive(ToSchema, Serialize, Deserialize)]
 pub(crate) struct Opportunity {
     /// BNA category subscore for access to job location areas.
     #[schema(minimum = 0, maximum = 100)]
-    employment: Option<f64>,
+    pub(crate) employment: Option<f64>,
     /// BNA category subscore for access to universities and colleges.
     #[schema(minimum = 0, maximum = 100)]
-    higher_education: Option<f64>,
+    pub(crate) higher_education: Option<f64>,
     /// BNA category subscore for access to k12 schools
     #[schema(minimum = 0, maximum = 100)]
-    k12_education: Option<f64>,
+    pub(crate) k12_education: Option<f64>,
     /// BNA category score for access to education and jobs.
     #[schema(minimum = 0, maximum = 100)]
-    score: Option<f64>,
+    pub(crate) score: Option<f64>,
     /// BNA category subscore for access to technical and vocational colleges.
     #[schema(minimum = 0, maximum = 100)]
-    technical_vocational_college: Option<f64>,
+    pub(crate) technical_vocational_college: Option<f64>,
 }
 
-#[derive(ToSchema, Serialize)]
+#[derive(ToSchema, Serialize, Deserialize)]
 pub(crate) struct CoreServices {
     /// BNA category subscore for access to dentists.
     #[schema(minimum = 0, maximum = 100)]
-    dentists: Option<f64>,
+    pub(crate) dentists: Option<f64>,
     /// BNA category subscore for access to doctors.
     #[schema(minimum = 0, maximum = 100)]
-    doctors: Option<f64>,
+    pub(crate) doctors: Option<f64>,
     /// BNA category subscore for access to grocery stores.
     #[schema(minimum = 0, maximum = 100)]
-    grocery: Option<f64>,
+    pub(crate) grocery: Option<f64>,
     /// BNA category subscore for access to hospitals.
     #[schema(minimum = 0, maximum = 100)]
-    hospitals: Option<f64>,
+    pub(crate) hospitals: Option<f64>,
     /// BNA category subscore for access to pharmacies.
     #[schema(minimum = 0, maximum = 100)]
-    pharmacies: Option<f64>,
+    pub(crate) pharmacies: Option<f64>,
     /// BNA category score for access to core services.
     #[schema(minimum = 0, maximum = 100)]
-    score: Option<f64>,
+    pub(crate) score: Option<f64>,
     /// BNA category subscore for access to social services.
     #[schema(minimum = 0, maximum = 100)]
-    social_services: Option<f64>,
+    pub(crate) social_services: Option<f64>,
 }
 
-#[derive(ToSchema, Serialize)]
+#[derive(ToSchema, Serialize, Deserialize)]
 pub(crate) struct People {
     /// BNA category score for access to residential areas.
     #[schema(minimum = 0, maximum = 100)]
-    people: Option<f64>,
+    pub(crate) people: Option<f64>,
 }
 
-#[derive(ToSchema, Serialize)]
+#[derive(ToSchema, Serialize, Deserialize)]
 pub(crate) struct Retail {
     /// BNA category score for access to major retail centers.
     #[schema(minimum = 0, maximum = 100)]
-    retail: Option<f64>,
+    pub(crate) retail: Option<f64>,
 }
 
-#[derive(ToSchema, Serialize)]
+#[derive(ToSchema, Serialize, Deserialize)]
 pub(crate) struct Transit {
     /// BNA category score for access to major transit stops.
     #[schema(minimum = 0, maximum = 100)]
-    transit: Option<f64>,
+    pub(crate) transit: Option<f64>,
 }
 
-#[derive(ToSchema, Serialize)]
+#[derive(ToSchema, Serialize, Deserialize)]
 pub(crate) struct Ratings(Vec<Rating>);
 
 impl From<Vec<Bna>> for Ratings {
@@ -189,39 +189,41 @@ impl From<Vec<Bna>> for Ratings {
     }
 }
 
-#[derive(ToSchema, Serialize)]
+#[derive(ToSchema, Serialize, Deserialize)]
 pub(crate) struct RatingWithCity {
     pub(crate) rating: Rating,
     pub(crate) city: City,
 }
 
-#[derive(ToSchema, Serialize)]
+#[derive(ToSchema, Serialize, Deserialize)]
 pub(crate) struct RatingPost {
     /// City identifier
-    city_id: Uuid,
+    pub(crate) city_id: Uuid,
     /// Rating version
     /// The format follows the [calver](https://calver.org) specification with
     /// the YY.0M[.Minor] scheme.
-    version: String,
+    pub(crate) version: String,
+    /// City rating score
+    pub(crate) score: f64,
 
     /// BNAInfrastructure
-    infrastructure: Infrastructure,
+    pub(crate) infrastructure: Infrastructure,
 
     /// BNA Recreation
-    recreation: Recreation,
+    pub(crate) recreation: Recreation,
 
     /// BNA Opportunity
-    opportunity: Opportunity,
+    pub(crate) opportunity: Opportunity,
 
     /// BNA Core Services
-    core_services: CoreServices,
+    pub(crate) core_services: CoreServices,
 
     /// BNA People
-    people: People,
+    pub(crate) people: People,
 
     /// BNA Retail
-    retail: Retail,
+    pub(crate) retail: Retail,
 
     /// BNA Transit
-    transit: Transit,
+    pub(crate) transit: Transit,
 }

--- a/lambdas/src/core/resource/schema.rs
+++ b/lambdas/src/core/resource/schema.rs
@@ -61,7 +61,7 @@ impl Display for Country {
     }
 }
 
-#[derive(ToSchema, Serialize)]
+#[derive(ToSchema, Serialize, Deserialize)]
 #[schema(description = "Detailed information of a city")]
 pub(crate) struct City {
     /// City identifier

--- a/lambdas/tests/endpoints/ratings.hurl
+++ b/lambdas/tests/endpoints/ratings.hurl
@@ -1,6 +1,5 @@
 # Queries the first page of the bnas.
 GET {{host}}/ratings
-
 HTTP 200
 [Asserts]
 jsonpath "$" count > 0
@@ -10,17 +9,14 @@ rating_id: jsonpath "$.[0].id"
 
 # Queries a specific bna run.
 GET {{host}}/ratings/{{rating_id}}
-
 HTTP 200
 
 # Queries a specific bna with an invalid id.
 GET {{host}}/ratings/1
-
 HTTP 400
 
 # Queries a non-existing bna run
 GET {{host}}/ratings/{{fake_rating_id}}
-
 HTTP 404
 [Asserts]
 jsonpath "$.errors" count == 1
@@ -28,14 +24,55 @@ jsonpath "$.errors[0].source.pointer" == "/ratings/{{fake_rating_id}}"
 
 # Queries a specific bna run and its associated city.
 GET {{host}}/ratings/{{rating_id}}/city
-
 HTTP 200
 [Asserts]
 
 # Queries a non-existing bna run and its associated city.
 GET {{host}}/ratings/{{fake_rating_id}}/city
-
 HTTP 404
 [Asserts]
 jsonpath "$.errors" count == 1
 jsonpath "$.errors[0].source.pointer" == "/ratings/{{fake_rating_id}}/city"
+
+# Post a new city rating
+POST {{host}}/ratings
+{
+  "city_id": "09c049b6-213b-405c-bc4e-178346ff814d",
+  "core_services": {
+    "dentists": 0,
+    "doctors": 0,
+    "grocery": 1.69,
+    "hospitals": 5.18,
+    "pharmacies": 0,
+    "score": 3.24
+  },
+  "infrastructure": {
+    "high_stress_miles": 64.5,
+    "low_stress_miles": 9.3
+  },
+  "opportunity": {
+    "employment": 8.26,
+    "higher_education": 0,
+    "k12_education": 8.31,
+    "score": 8.29,
+    "technical_vocational_college": 0
+  },
+  "people": {
+    "people": 19.17
+  },
+  "recreation": {
+    "community_centers": 0,
+    "parks": 7.13,
+    "score": 7.13,
+    "trails": 0
+  },
+  "retail": {
+    "retail": 0
+  },
+  "transit": {
+    "transit": 0
+  },
+  "version": "24.12",
+  "score": 8.93
+}
+HTTP 201

--- a/lambdas/tests/justfile
+++ b/lambdas/tests/justfile
@@ -25,8 +25,8 @@ test *env:
     endpoints/cities.hurl
 
 # Run the smoke tests against an environment [localhost, staging].
-test-smoke-readonly *env:
-  hurl --test --variables-file $1.vars smoke/public-readonly.hurl
+test-smoke-public *env:
+  hurl --test --variables-file $1.vars smoke/public.hurl
 
 # Run the schemathesis tests locally again the openapi schema.
 test-localhost-schemathesis:

--- a/openapi-3.0.yaml
+++ b/openapi-3.0.yaml
@@ -2568,6 +2568,7 @@ components:
       required:
         - city_id
         - version
+        - score
         - infrastructure
         - recreation
         - opportunity
@@ -2592,6 +2593,10 @@ components:
           $ref: '#/components/schemas/Recreation'
         retail:
           $ref: '#/components/schemas/Retail'
+        score:
+          type: number
+          format: double
+          description: City rating score
         transit:
           $ref: '#/components/schemas/Transit'
         version:

--- a/openapi-3.1.yaml
+++ b/openapi-3.1.yaml
@@ -2401,6 +2401,7 @@ components:
       required:
       - city_id
       - version
+      - score
       - infrastructure
       - recreation
       - opportunity
@@ -2431,6 +2432,10 @@ components:
         retail:
           $ref: '#/components/schemas/Retail'
           description: BNA Retail
+        score:
+          type: number
+          format: double
+          description: City rating score
         transit:
           $ref: '#/components/schemas/Transit'
           description: BNA Transit


### PR DESCRIPTION
Fixes the POST `/ratings` endpoint by adding the missing `score` field.

The Open API Specifications and the bna client were updated accordingly.

A new integration test was added into the scenario tests.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
