### PR TITLE
Add `/cities/top` endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,7 +1077,7 @@ dependencies = [
 
 [[package]]
 name = "bnaclient"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "bytes",
  "chrono",

--- a/bnaclient/CHANGELOG.md
+++ b/bnaclient/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.2.0] - 2025-07-09
+
+### Added
+
+- Added `/cities/top` endpoint to get the top N cities for a given year. [#300]
+
+[#300]: https://github.com/PeopleForBikes/bna-api/pull/300
+[1.2.0]: https://github.com/PeopleForBikes/bna-api/releases/tag/1.2.0

--- a/bnaclient/Cargo.toml
+++ b/bnaclient/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bnaclient"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 license = "MIT"
 

--- a/bnaclient/src/lib.rs
+++ b/bnaclient/src/lib.rs
@@ -849,6 +849,47 @@ pub mod types {
         }
     }
 
+    ///`CitiesWithSummary`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "array",
+    ///  "items": {
+    ///    "$ref": "#/components/schemas/CityWithSummary"
+    ///  }
+    ///}
+    /// ```
+    /// </details>
+    #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+    #[serde(transparent)]
+    pub struct CitiesWithSummary(pub ::std::vec::Vec<CityWithSummary>);
+    impl ::std::ops::Deref for CitiesWithSummary {
+        type Target = ::std::vec::Vec<CityWithSummary>;
+        fn deref(&self) -> &::std::vec::Vec<CityWithSummary> {
+            &self.0
+        }
+    }
+
+    impl ::std::convert::From<CitiesWithSummary> for ::std::vec::Vec<CityWithSummary> {
+        fn from(value: CitiesWithSummary) -> Self {
+            value.0
+        }
+    }
+
+    impl ::std::convert::From<&CitiesWithSummary> for CitiesWithSummary {
+        fn from(value: &CitiesWithSummary) -> Self {
+            value.clone()
+        }
+    }
+
+    impl ::std::convert::From<::std::vec::Vec<CityWithSummary>> for CitiesWithSummary {
+        fn from(value: ::std::vec::Vec<CityWithSummary>) -> Self {
+            Self(value)
+        }
+    }
+
     ///Detailed information of a city
     ///
     /// <details><summary>JSON schema</summary>
@@ -1183,6 +1224,46 @@ pub mod types {
 
     impl CityRatings {
         pub fn builder() -> builder::CityRatings {
+            Default::default()
+        }
+    }
+
+    ///`CityWithSummary`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "object",
+    ///  "required": [
+    ///    "city",
+    ///    "sumary"
+    ///  ],
+    ///  "properties": {
+    ///    "city": {
+    ///      "$ref": "#/components/schemas/City"
+    ///    },
+    ///    "sumary": {
+    ///      "$ref": "#/components/schemas/RatingSummary"
+    ///    }
+    ///  }
+    ///}
+    /// ```
+    /// </details>
+    #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+    pub struct CityWithSummary {
+        pub city: City,
+        pub sumary: RatingSummary,
+    }
+
+    impl ::std::convert::From<&CityWithSummary> for CityWithSummary {
+        fn from(value: &CityWithSummary) -> Self {
+            value.clone()
+        }
+    }
+
+    impl CityWithSummary {
+        pub fn builder() -> builder::CityWithSummary {
             Default::default()
         }
     }
@@ -2274,6 +2355,8 @@ pub mod types {
     ///    "city_id",
     ///    "created_at",
     ///    "id",
+    ///    "pop_size",
+    ///    "population",
     ///    "score",
     ///    "version"
     ///  ],
@@ -2292,6 +2375,32 @@ pub mod types {
     ///      "description": "Analysis identifier",
     ///      "type": "string",
     ///      "format": "uuid"
+    ///    },
+    ///    "pop_size": {
+    ///      "description": "City population size category (small, medium,
+    /// large).",
+    ///      "examples": [
+    ///        "large"
+    ///      ],
+    ///      "type": "integer",
+    ///      "format": "int32"
+    ///    },
+    ///    "population": {
+    ///      "description": "City population based on the annual U.S. Census
+    /// American Community Survey.",
+    ///      "examples": [
+    ///        "989252"
+    ///      ],
+    ///      "type": "integer",
+    ///      "format": "int32"
+    ///    },
+    ///    "residential_speed_limit_override": {
+    ///      "description": "Residential speed limit override.",
+    ///      "type": [
+    ///        "integer",
+    ///        "null"
+    ///      ],
+    ///      "format": "int32"
     ///    },
     ///    "score": {
     ///      "description": "BNA score",
@@ -2320,6 +2429,14 @@ pub mod types {
         pub created_at: ::chrono::DateTime<::chrono::offset::Utc>,
         ///Analysis identifier
         pub id: ::uuid::Uuid,
+        ///City population size category (small, medium, large).
+        pub pop_size: i32,
+        ///City population based on the annual U.S. Census American Community
+        /// Survey.
+        pub population: i32,
+        ///Residential speed limit override.
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        pub residential_speed_limit_override: ::std::option::Option<i32>,
         pub score: f64,
         ///Analysis version. The format follows the [calver](https://calver.org)
         ///specification with the YY.0M[.Minor] scheme.
@@ -4235,6 +4352,65 @@ pub mod types {
         }
 
         #[derive(Clone, Debug)]
+        pub struct CityWithSummary {
+            city: ::std::result::Result<super::City, ::std::string::String>,
+            sumary: ::std::result::Result<super::RatingSummary, ::std::string::String>,
+        }
+
+        impl ::std::default::Default for CityWithSummary {
+            fn default() -> Self {
+                Self {
+                    city: Err("no value supplied for city".to_string()),
+                    sumary: Err("no value supplied for sumary".to_string()),
+                }
+            }
+        }
+
+        impl CityWithSummary {
+            pub fn city<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::City>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.city = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for city: {}", e));
+                self
+            }
+            pub fn sumary<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::RatingSummary>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.sumary = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for sumary: {}", e));
+                self
+            }
+        }
+
+        impl ::std::convert::TryFrom<CityWithSummary> for super::CityWithSummary {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: CityWithSummary,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    city: value.city?,
+                    sumary: value.sumary?,
+                })
+            }
+        }
+
+        impl ::std::convert::From<super::CityWithSummary> for CityWithSummary {
+            fn from(value: super::CityWithSummary) -> Self {
+                Self {
+                    city: Ok(value.city),
+                    sumary: Ok(value.sumary),
+                }
+            }
+        }
+
+        #[derive(Clone, Debug)]
         pub struct CoreServices {
             dentists: ::std::result::Result<::std::option::Option<f64>, ::std::string::String>,
             doctors: ::std::result::Result<::std::option::Option<f64>, ::std::string::String>,
@@ -5200,6 +5376,10 @@ pub mod types {
                 ::std::string::String,
             >,
             id: ::std::result::Result<::uuid::Uuid, ::std::string::String>,
+            pop_size: ::std::result::Result<i32, ::std::string::String>,
+            population: ::std::result::Result<i32, ::std::string::String>,
+            residential_speed_limit_override:
+                ::std::result::Result<::std::option::Option<i32>, ::std::string::String>,
             score: ::std::result::Result<f64, ::std::string::String>,
             version: ::std::result::Result<::std::string::String, ::std::string::String>,
         }
@@ -5210,6 +5390,9 @@ pub mod types {
                     city_id: Err("no value supplied for city_id".to_string()),
                     created_at: Err("no value supplied for created_at".to_string()),
                     id: Err("no value supplied for id".to_string()),
+                    pop_size: Err("no value supplied for pop_size".to_string()),
+                    population: Err("no value supplied for population".to_string()),
+                    residential_speed_limit_override: Ok(Default::default()),
                     score: Err("no value supplied for score".to_string()),
                     version: Err("no value supplied for version".to_string()),
                 }
@@ -5247,6 +5430,39 @@ pub mod types {
                     .map_err(|e| format!("error converting supplied value for id: {}", e));
                 self
             }
+            pub fn pop_size<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<i32>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.pop_size = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for pop_size: {}", e));
+                self
+            }
+            pub fn population<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<i32>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.population = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for population: {}", e));
+                self
+            }
+            pub fn residential_speed_limit_override<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::option::Option<i32>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.residential_speed_limit_override = value.try_into().map_err(|e| {
+                    format!(
+                        "error converting supplied value for residential_speed_limit_override: {}",
+                        e
+                    )
+                });
+                self
+            }
             pub fn score<T>(mut self, value: T) -> Self
             where
                 T: ::std::convert::TryInto<f64>,
@@ -5278,6 +5494,9 @@ pub mod types {
                     city_id: value.city_id?,
                     created_at: value.created_at?,
                     id: value.id?,
+                    pop_size: value.pop_size?,
+                    population: value.population?,
+                    residential_speed_limit_override: value.residential_speed_limit_override?,
                     score: value.score?,
                     version: value.version?,
                 })
@@ -5290,6 +5509,9 @@ pub mod types {
                     city_id: Ok(value.city_id),
                     created_at: Ok(value.created_at),
                     id: Ok(value.id),
+                    pop_size: Ok(value.pop_size),
+                    population: Ok(value.population),
+                    residential_speed_limit_override: Ok(value.residential_speed_limit_override),
                     score: Ok(value.score),
                     version: Ok(value.version),
                 }
@@ -6316,6 +6538,24 @@ impl Client {
         builder::PatchCitiesSubmission::new(self)
     }
 
+    ///Get the top N cities for a specific year.
+    ///
+    ///Sends a `GET` request to `/cities/top/{year}/{count}`
+    ///
+    ///Arguments:
+    /// - `year`: The year to collect the top cities for
+    /// - `count`: The number of top cities to collect
+    ///```ignore
+    /// let response = client.get_top_cities()
+    ///    .year(year)
+    ///    .count(count)
+    ///    .send()
+    ///    .await;
+    /// ```
+    pub fn get_top_cities(&self) -> builder::GetTopCities {
+        builder::GetTopCities::new(self)
+    }
+
     ///Get the details of a specific city where an BNA analysis was computed.
     ///
     ///Sends a `GET` request to `/cities/{country}/{region}/{name}`
@@ -7084,6 +7324,98 @@ pub mod builder {
                     ::reqwest::header::HeaderValue::from_static("application/json"),
                 )
                 .json(&body)
+                .headers(header_map)
+                .build()?;
+            let result = client.client.execute(request).await;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
+                400u16 => Err(Error::ErrorResponse(
+                    ResponseValue::from_response(response).await?,
+                )),
+                401u16 => Err(Error::ErrorResponse(
+                    ResponseValue::from_response(response).await?,
+                )),
+                403u16 => Err(Error::ErrorResponse(
+                    ResponseValue::from_response(response).await?,
+                )),
+                404u16 => Err(Error::ErrorResponse(
+                    ResponseValue::from_response(response).await?,
+                )),
+                _ => Err(Error::UnexpectedResponse(response)),
+            }
+        }
+    }
+
+    ///Builder for [`Client::get_top_cities`]
+    ///
+    ///[`Client::get_top_cities`]: super::Client::get_top_cities
+    #[derive(Debug, Clone)]
+    pub struct GetTopCities<'a> {
+        client: &'a super::Client,
+        year: Result<i32, String>,
+        count: Result<::std::num::NonZeroU32, String>,
+    }
+
+    impl<'a> GetTopCities<'a> {
+        pub fn new(client: &'a super::Client) -> Self {
+            Self {
+                client: client,
+                year: Err("year was not initialized".to_string()),
+                count: Err("count was not initialized".to_string()),
+            }
+        }
+
+        pub fn year<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<i32>,
+        {
+            self.year = value
+                .try_into()
+                .map_err(|_| "conversion to `i32` for year failed".to_string());
+            self
+        }
+
+        pub fn count<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::num::NonZeroU32>,
+        {
+            self.count = value.try_into().map_err(|_| {
+                "conversion to `:: std :: num :: NonZeroU32` for count failed".to_string()
+            });
+            self
+        }
+
+        ///Sends a `GET` request to `/cities/top/{year}/{count}`
+        pub async fn send(
+            self,
+        ) -> Result<ResponseValue<types::CitiesWithSummary>, Error<types::ApiErrors>> {
+            let Self {
+                client,
+                year,
+                count,
+            } = self;
+            let year = year.map_err(Error::InvalidRequest)?;
+            let count = count.map_err(Error::InvalidRequest)?;
+            let url = format!(
+                "{}/cities/top/{}/{}",
+                client.baseurl,
+                encode_path(&year.to_string()),
+                encode_path(&count.to_string()),
+            );
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(client.api_version()),
+            );
+            #[allow(unused_mut)]
+            let mut request = client
+                .client
+                .get(url)
+                .header(
+                    ::reqwest::header::ACCEPT,
+                    ::reqwest::header::HeaderValue::from_static("application/json"),
+                )
                 .headers(header_map)
                 .build()?;
             let result = client.client.execute(request).await;

--- a/entity/src/wrappers/mod.rs
+++ b/entity/src/wrappers/mod.rs
@@ -75,7 +75,7 @@ impl FromStr for BnaRegion {
 impl Display for BnaRegion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let value = serde_plain::to_string(&self).expect("cannot serialize value");
-        write!(f, "{}", value)
+        write!(f, "{value}")
     }
 }
 

--- a/lambdas/src/core/resource/pipelines/schema.rs
+++ b/lambdas/src/core/resource/pipelines/schema.rs
@@ -25,7 +25,7 @@ impl FromStr for PipelineStatus {
 impl Display for PipelineStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let value = serde_plain::to_string(&self).expect("cannot serialize value");
-        write!(f, "{}", value)
+        write!(f, "{value}")
     }
 }
 
@@ -155,7 +155,7 @@ impl FromStr for BnaPipelineStep {
 impl Display for BnaPipelineStep {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let value = serde_plain::to_string(&self).expect("cannot serialize value");
-        write!(f, "{}", value)
+        write!(f, "{value}")
     }
 }
 

--- a/lambdas/src/core/resource/ratings/db.rs
+++ b/lambdas/src/core/resource/ratings/db.rs
@@ -315,20 +315,6 @@ pub async fn fetch_ratings_city(
         }
         None => Ok(None),
     }
-    // let bna = fetch_rating(db, rating_id).await?;
-    // match bna {
-    //     Some(bna) => {
-    //         let a = summary::Entity::find_by_id(rating_id)
-    //             .find_also_related(city::Entity)
-    //             .one(db)
-    //             .await?;
-    //         Ok((bna, city: city.expect("a city must be attached to a rating")))
-    //     }
-    //     None => Err(ExecutionError::NotFound(
-    //         ctx.request_id(),
-    //         ctx.source(),
-    //         format!("cannot find a rating with id {rating_id}"),
-    //     )),
 }
 
 pub async fn fetch_rating(

--- a/lambdas/src/core/resource/schema.rs
+++ b/lambdas/src/core/resource/schema.rs
@@ -57,7 +57,7 @@ impl From<String> for Country {
 impl Display for Country {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let value = serde_plain::to_string(&self).expect("cannot serialize value");
-        write!(f, "{}", value)
+        write!(f, "{value}")
     }
 }
 
@@ -284,7 +284,7 @@ impl From<String> for BikeLaneType {
 impl Display for BikeLaneType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let value = serde_plain::to_string(&self).expect("cannot serialize value");
-        write!(f, "{}", value)
+        write!(f, "{value}")
     }
 }
 impl From<entity::wrappers::BikeLaneType> for BikeLaneType {

--- a/lambdas/tests/endpoints/cities.hurl
+++ b/lambdas/tests/endpoints/cities.hurl
@@ -38,4 +38,9 @@ HTTP 404
 jsonpath "$.errors" count == 1
 jsonpath "$.errors[0].source.pointer" == "/cities/United%20States/{{region}}/unknown_city/ratings"
 
+# Query the top 10 cities for 2024
+GET {{host}}/cities/top/2024/10
 
+HTTP 200
+[Asserts]
+jsonpath "$" count <= 10

--- a/lambdas/tests/smoke/public.hurl
+++ b/lambdas/tests/smoke/public.hurl
@@ -25,6 +25,13 @@ HTTP 200
 GET {{host}}/cities/{{country}}/{{region}}/{{name}}/ratings
 HTTP 200
 
+# Query the top 10 cities for 2024
+GET {{host}}/cities/top/2024/10
+
+HTTP 200
+[Asserts]
+jsonpath "$" count <= 10
+
 # Create a new submission.
 POST {{host}}/cities/submissions
 content-type: application/json

--- a/openapi-3.0.yaml
+++ b/openapi-3.0.yaml
@@ -519,6 +519,108 @@ paths:
                       pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
                     status: '404'
                     title: Item Not Found
+  /cities/top/{year}/{count}:
+    get:
+      tags:
+        - city
+      description: Get the top N cities for a specific year.
+      operationId: get_top_cities
+      parameters:
+        - name: year
+          in: path
+          description: The year to collect the top cities for
+          required: true
+          schema:
+            type: integer
+            format: int32
+            maximum: 2029
+            minimum: 2017
+          example: '2024'
+        - name: count
+          in: path
+          description: The number of top cities to collect
+          required: true
+          schema:
+            type: integer
+            format: int32
+            maximum: 25
+            minimum: 1
+          example: '10'
+      responses:
+        '200':
+          description: Fetches cities with their respective summary
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CitiesWithSummary'
+        '400':
+          description: >-
+            The request was formatted incorrectly or missing required
+            parameters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - details: >-
+                      the request was formatted incorrectly or missing required
+                      parameters
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      parameter: status
+                    status: '400'
+                    title: Bad Request
+        '401':
+          description: >-
+            The request has not been fulfilled because it lacks valid
+            authentication credentials for the target resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - details: >-
+                      invalid authentication credentials to access the specified
+                      resource
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '401'
+                    title: Unauthorized
+        '403':
+          description: >-
+            Forbidden to make the request. Most likely this indicates an issue
+            with the credentials or permissions.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - details: access to the requested resource is forbidden
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '403'
+                    title: Forbidden
+        '404':
+          description: >-
+            The particular resource requested was not found. This occurs, for
+            example, when the id of the requested  resource does not exist.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIErrors'
+              example:
+                errors:
+                  - details: the resource was not found
+                    id: blfwkg8nvHcEJnQ=
+                    source:
+                      pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                    status: '404'
+                    title: Item Not Found
   /cities/{country}/{region}/{name}:
     get:
       tags:
@@ -1865,6 +1967,10 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/City'
+    CitiesWithSummary:
+      type: array
+      items:
+        $ref: '#/components/schemas/CityWithSummary'
     City:
       type: object
       description: Detailed information of a city
@@ -2013,6 +2119,16 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/RatingSummary'
+    CityWithSummary:
+      type: object
+      required:
+        - city
+        - sumary
+      properties:
+        city:
+          $ref: '#/components/schemas/City'
+        sumary:
+          $ref: '#/components/schemas/RatingSummary'
     CoreServices:
       type: object
       properties:
@@ -2353,6 +2469,8 @@ components:
         - id
         - city_id
         - created_at
+        - pop_size
+        - population
         - score
         - version
       properties:
@@ -2368,6 +2486,23 @@ components:
           type: string
           format: uuid
           description: Analysis identifier
+        pop_size:
+          type: integer
+          format: int32
+          description: City population size category (small, medium, large).
+          example: large
+        population:
+          type: integer
+          format: int32
+          description: >-
+            City population based on the annual U.S. Census American Community
+            Survey.
+          example: '989252'
+        residential_speed_limit_override:
+          type: integer
+          format: int32
+          description: Residential speed limit override.
+          nullable: true
         score:
           type: number
           format: double

--- a/openapi-3.1.yaml
+++ b/openapi-3.1.yaml
@@ -459,6 +459,96 @@ paths:
                     pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
                   status: '404'
                   title: Item Not Found
+  /cities/top/{year}/{count}:
+    get:
+      tags:
+      - city
+      description: Get the top N cities for a specific year.
+      operationId: get_top_cities
+      parameters:
+      - name: year
+        in: path
+        description: The year to collect the top cities for
+        required: true
+        schema:
+          type: integer
+          format: int32
+          maximum: 2029
+          minimum: 2017
+        example: '2024'
+      - name: count
+        in: path
+        description: The number of top cities to collect
+        required: true
+        schema:
+          type: integer
+          format: int32
+          maximum: 25
+          minimum: 1
+        example: '10'
+      responses:
+        '200':
+          description: Fetches cities with their respective summary
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CitiesWithSummary'
+        '400':
+          description: The request was formatted incorrectly or missing required parameters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIErrors'
+              example:
+                errors:
+                - details: the request was formatted incorrectly or missing required parameters
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    parameter: status
+                  status: '400'
+                  title: Bad Request
+        '401':
+          description: The request has not been fulfilled because it lacks valid authentication credentials for the target resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIErrors'
+              example:
+                errors:
+                - details: invalid authentication credentials to access the specified resource
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '401'
+                  title: Unauthorized
+        '403':
+          description: Forbidden to make the request. Most likely this indicates an issue with the credentials or permissions.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIErrors'
+              example:
+                errors:
+                - details: access to the requested resource is forbidden
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '403'
+                  title: Forbidden
+        '404':
+          description: The particular resource requested was not found. This occurs, for example, when the id of the requested  resource does not exist.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIErrors'
+              example:
+                errors:
+                - details: the resource was not found
+                  id: blfwkg8nvHcEJnQ=
+                  source:
+                    pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
+                  status: '404'
+                  title: Item Not Found
   /cities/{country}/{region}/{name}:
     get:
       tags:
@@ -1696,6 +1786,10 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/City'
+    CitiesWithSummary:
+      type: array
+      items:
+        $ref: '#/components/schemas/CityWithSummary'
     City:
       type: object
       description: Detailed information of a city
@@ -1857,6 +1951,16 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/RatingSummary'
+    CityWithSummary:
+      type: object
+      required:
+      - city
+      - sumary
+      properties:
+        city:
+          $ref: '#/components/schemas/City'
+        sumary:
+          $ref: '#/components/schemas/RatingSummary'
     CoreServices:
       type: object
       properties:
@@ -2231,6 +2335,8 @@ components:
       - id
       - city_id
       - created_at
+      - pop_size
+      - population
       - score
       - version
       properties:
@@ -2246,6 +2352,24 @@ components:
           type: string
           format: uuid
           description: Analysis identifier
+        pop_size:
+          type: integer
+          format: int32
+          description: City population size category (small, medium, large).
+          examples:
+          - large
+        population:
+          type: integer
+          format: int32
+          description: City population based on the annual U.S. Census American Community Survey.
+          examples:
+          - '989252'
+        residential_speed_limit_override:
+          type:
+          - integer
+          - 'null'
+          format: int32
+          description: Residential speed limit override.
         score:
           type: number
           format: double


### PR DESCRIPTION
Adds a new endpoint to get the top N cities for a given year.

The integration tests were updated accordingly and the OpenAPI
specifications were regenerated..

Drive-bys:
- Regenerates `bna-client`, v1.2.0.
- Updates `RatingSummary` struct to match the new database design.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
