### PR TITLE
Add /cities/summary/latest endpoint

### DIFF
--- a/bnaclient/src/lib.rs
+++ b/bnaclient/src/lib.rs
@@ -6554,6 +6554,24 @@ impl Client {
         builder::PatchCitiesSubmission::new(self)
     }
 
+    ///Get all cities with their latest summary.
+    ///
+    ///Sends a `GET` request to `/cities/summary/latest`
+    ///
+    ///```ignore
+    /// let response = client.get_cities_latest_summary()
+    ///    .latest(latest)
+    ///    .order_direction(order_direction)
+    ///    .page(page)
+    ///    .page_size(page_size)
+    ///    .sort_by(sort_by)
+    ///    .send()
+    ///    .await;
+    /// ```
+    pub fn get_cities_latest_summary(&self) -> builder::GetCitiesLatestSummary<'_> {
+        builder::GetCitiesLatestSummary::new(self)
+    }
+
     ///Get the top N cities for a specific year.
     ///
     ///Sends a `GET` request to `/cities/top/{year}/{count}`
@@ -7492,6 +7510,135 @@ pub mod builder {
         }
     }
 
+    ///Builder for [`Client::get_cities_latest_summary`]
+    ///
+    ///[`Client::get_cities_latest_summary`]: super::Client::get_cities_latest_summary
+    #[derive(Debug, Clone)]
+    pub struct GetCitiesLatestSummary<'a> {
+        client: &'a super::Client,
+        latest: Result<Option<bool>, String>,
+        order_direction: Result<Option<types::OrderDirection>, String>,
+        page: Result<Option<::std::num::NonZeroU64>, String>,
+        page_size: Result<Option<::std::num::NonZeroU64>, String>,
+        sort_by: Result<Option<::std::string::String>, String>,
+    }
+
+    impl<'a> GetCitiesLatestSummary<'a> {
+        pub fn new(client: &'a super::Client) -> Self {
+            Self {
+                client: client,
+                latest: Ok(None),
+                order_direction: Ok(None),
+                page: Ok(None),
+                page_size: Ok(None),
+                sort_by: Ok(None),
+            }
+        }
+
+        pub fn latest<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<bool>,
+        {
+            self.latest = value
+                .try_into()
+                .map(Some)
+                .map_err(|_| "conversion to `bool` for latest failed".to_string());
+            self
+        }
+
+        pub fn order_direction<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<types::OrderDirection>,
+        {
+            self.order_direction = value.try_into().map(Some).map_err(|_| {
+                "conversion to `OrderDirection` for order_direction failed".to_string()
+            });
+            self
+        }
+
+        pub fn page<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::num::NonZeroU64>,
+        {
+            self.page = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: num :: NonZeroU64` for page failed".to_string()
+            });
+            self
+        }
+
+        pub fn page_size<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::num::NonZeroU64>,
+        {
+            self.page_size = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: num :: NonZeroU64` for page_size failed".to_string()
+            });
+            self
+        }
+
+        pub fn sort_by<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<::std::string::String>,
+        {
+            self.sort_by = value.try_into().map(Some).map_err(|_| {
+                "conversion to `:: std :: string :: String` for sort_by failed".to_string()
+            });
+            self
+        }
+
+        ///Sends a `GET` request to `/cities/summary/latest`
+        pub async fn send(self) -> Result<ResponseValue<types::CitiesWithSummary>, Error<()>> {
+            let Self {
+                client,
+                latest,
+                order_direction,
+                page,
+                page_size,
+                sort_by,
+            } = self;
+            let latest = latest.map_err(Error::InvalidRequest)?;
+            let order_direction = order_direction.map_err(Error::InvalidRequest)?;
+            let page = page.map_err(Error::InvalidRequest)?;
+            let page_size = page_size.map_err(Error::InvalidRequest)?;
+            let sort_by = sort_by.map_err(Error::InvalidRequest)?;
+            let url = format!("{}/cities/summary/latest", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            header_map.append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(super::Client::api_version()),
+            );
+            #[allow(unused_mut)]
+            let mut request = client
+                .client
+                .get(url)
+                .header(
+                    ::reqwest::header::ACCEPT,
+                    ::reqwest::header::HeaderValue::from_static("application/json"),
+                )
+                .query(&progenitor_client::QueryParam::new("latest", &latest))
+                .query(&progenitor_client::QueryParam::new(
+                    "order_direction",
+                    &order_direction,
+                ))
+                .query(&progenitor_client::QueryParam::new("page", &page))
+                .query(&progenitor_client::QueryParam::new("page_size", &page_size))
+                .query(&progenitor_client::QueryParam::new("sort_by", &sort_by))
+                .headers(header_map)
+                .build()?;
+            let info = OperationInfo {
+                operation_id: "get_cities_latest_summary",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
+                _ => Err(Error::UnexpectedResponse(response)),
+            }
+        }
+    }
+
     ///Builder for [`Client::get_top_cities`]
     ///
     ///[`Client::get_top_cities`]: super::Client::get_top_cities
@@ -7499,7 +7646,7 @@ pub mod builder {
     pub struct GetTopCities<'a> {
         client: &'a super::Client,
         year: Result<i32, String>,
-        count: Result<::std::num::NonZeroU32, String>,
+        count: Result<::std::num::NonZeroU64, String>,
     }
 
     impl<'a> GetTopCities<'a> {
@@ -7523,10 +7670,10 @@ pub mod builder {
 
         pub fn count<V>(mut self, value: V) -> Self
         where
-            V: std::convert::TryInto<::std::num::NonZeroU32>,
+            V: std::convert::TryInto<::std::num::NonZeroU64>,
         {
             self.count = value.try_into().map_err(|_| {
-                "conversion to `:: std :: num :: NonZeroU32` for count failed".to_string()
+                "conversion to `:: std :: num :: NonZeroU64` for count failed".to_string()
             });
             self
         }

--- a/lambdas/requests.rest
+++ b/lambdas/requests.rest
@@ -1,4 +1,3 @@
-@host=https://origin-api.peopleforbikes.xyz
 # @host=http://localhost:3000
 # Austin, TX, USA.
 @city_id=ef8384d5-b96f-439d-a83b-bc801735ddc6
@@ -230,3 +229,8 @@ Authorization: Bearer {{cognito_access}}
     "state_abbrev": "VC",
     "speed_limit": null,
 }
+
+### Get the top 10 cities by score.
+GET {{host}}/cities/top/2026/10
+content-type: application/json
+Authorization: Bearer {{cognito_access}}

--- a/lambdas/src/core/resource/cities/adaptor.rs
+++ b/lambdas/src/core/resource/cities/adaptor.rs
@@ -1,6 +1,7 @@
 use super::db::{
     fetch_cities, fetch_cities_ratings, fetch_cities_submission, fetch_cities_submissions,
-    fetch_city, fetch_country, fetch_state_region_crosswalk, fetch_top_cities,
+    fetch_cities_with_latest_summary, fetch_city, fetch_country, fetch_state_region_crosswalk,
+    fetch_top_cities,
 };
 use crate::{core::resource::schema::OrderDirection, Context, ExecutionError};
 use entity::{
@@ -183,7 +184,7 @@ pub async fn post_cities_submission_adaptor(
 pub(crate) async fn get_top_cities_adaptor(
     db: &DatabaseConnection,
     year: i32,
-    count: i32,
+    count: u64,
     ctx: Context,
 ) -> Result<Vec<(city::Model, summary::Model)>, ExecutionError> {
     // Fetch the top cities and their associated summaries.
@@ -202,4 +203,15 @@ pub(crate) async fn get_top_cities_adaptor(
             format!("cannot fetch the {count} top cities for the year {year}"),
         )),
     }
+}
+
+pub async fn get_cities_latest_summary_adaptor(
+    db: &DatabaseConnection,
+    sort_direction: OrderDirection,
+    sort_by: &str,
+    page: u64,
+    page_size: u64,
+) -> Result<(u64, Vec<(city::Model, summary::Model)>), ExecutionError> {
+    // Fetch all cities with their latest summary.
+    Ok(fetch_cities_with_latest_summary(db, sort_direction, sort_by, page, page_size).await?)
 }

--- a/lambdas/src/core/resource/cities/db.rs
+++ b/lambdas/src/core/resource/cities/db.rs
@@ -1,11 +1,23 @@
 use crate::core::resource::schema::OrderDirection;
-use entity::{city, country, state_region_crosswalk, submission, summary, Summary};
+use entity::{city, country, state_region_crosswalk, submission, summary};
 use sea_orm::{
     ColumnTrait, Condition, DatabaseBackend, DatabaseConnection, DbErr, EntityTrait,
-    FromQueryResult, PaginatorTrait, QueryFilter, QueryOrder, QuerySelect, Statement,
+    FromQueryResult, LoaderTrait, PaginatorTrait, QueryFilter, QueryOrder, QuerySelect, Statement,
 };
 use serde::Serialize;
 use uuid::Uuid;
+
+pub(crate) fn city_column(header: &str) -> city::Column {
+    match header {
+        "name" => city::Column::Name,
+        "country" => city::Column::Country,
+        "state" => city::Column::State,
+        "state_abbrev" => city::Column::StateAbbrev,
+        "region" => city::Column::Region,
+        "fips_code" => city::Column::FipsCode,
+        _ => city::Column::CreatedAt,
+    }
+}
 
 pub(crate) async fn fetch_city(
     db: &DatabaseConnection,
@@ -25,15 +37,7 @@ pub(crate) async fn fetch_cities(
     page: u64,
     page_size: u64,
 ) -> Result<(u64, Vec<city::Model>), DbErr> {
-    let sort_column = match sort_by {
-        "name" => city::Column::Name,
-        "country" => city::Column::Country,
-        "state" => city::Column::State,
-        "state_abbrev" => city::Column::StateAbbrev,
-        "region" => city::Column::Region,
-        "fips_code" => city::Column::FipsCode,
-        _ => city::Column::CreatedAt,
-    };
+    let sort_column = city_column(sort_by);
     let mut select = city::Entity::find();
     let count = select
         .clone()
@@ -140,7 +144,7 @@ struct SummaryID {
 pub(crate) async fn fetch_top_cities(
     db: &DatabaseConnection,
     year: i32,
-    count: i32,
+    count: u64,
 ) -> Result<Option<Vec<(city::Model, summary::Model)>>, DbErr> {
     // Define a custom query to fetch the top N summary IDs of a specific year.
     let query = r#"
@@ -187,7 +191,7 @@ pub(crate) async fn fetch_top_cities(
     let mut cities_with_summaries: Vec<(city::Model, summary::Model)> =
         Vec::with_capacity(summary_ids.len());
     for summary_id in summary_ids {
-        let (summary, opt_city) = Summary::find_by_id(summary_id.id)
+        let (summary, opt_city) = summary::Entity::find_by_id(summary_id.id)
             .find_also_related(entity::City)
             .one(db)
             .await?
@@ -196,4 +200,44 @@ pub(crate) async fn fetch_top_cities(
         cities_with_summaries.push((city, summary));
     }
     Ok(Some(cities_with_summaries))
+}
+
+pub(crate) async fn fetch_cities_with_latest_summary(
+    db: &DatabaseConnection,
+    sort_direction: OrderDirection,
+    sort_by: &str,
+    page: u64,
+    page_size: u64,
+) -> Result<(u64, Vec<(city::Model, summary::Model)>), DbErr> {
+    // Query the total city count for pagination metadata.
+    let total_items = city::Entity::find().count(db).await?;
+
+    // Query one page of cities, alphabetically.
+    let sort_column = city_column(sort_by);
+    let cities = city::Entity::find()
+        .order_by(sort_column, sort_direction.into())
+        .limit(page_size)
+        .offset(page * page_size)
+        .all(db)
+        .await?;
+
+    // Query the latest summary for this page's cities.
+    let summaries_per_city = cities
+        .load_many(
+            summary::Entity::find().order_by_desc(summary::Column::CreatedAt),
+            db,
+        )
+        .await?;
+
+    // Zip cities with their latest summary.
+    let items = cities
+        .into_iter()
+        .zip(summaries_per_city)
+        .filter(|(_city, summaries)| !summaries.is_empty())
+        .map(|(city, mut summaries)| {
+            let latest = summaries.swap_remove(0);
+            (city, latest)
+        })
+        .collect();
+    Ok((total_items, items))
 }

--- a/lambdas/src/core/resource/cities/endpoint.rs
+++ b/lambdas/src/core/resource/cities/endpoint.rs
@@ -1,19 +1,19 @@
 use super::{
     adaptor::{
-        get_cities_adaptor, get_cities_ratings_adaptor, get_cities_submission_adaptor,
-        get_cities_submissions_adaptor, get_city_adaptor, patch_cities_submission_adaptor,
-        post_cities_adaptor, post_cities_submission_adaptor,
+        get_cities_adaptor, get_cities_latest_summary_adaptor, get_cities_ratings_adaptor,
+        get_cities_submission_adaptor, get_cities_submissions_adaptor, get_city_adaptor,
+        patch_cities_submission_adaptor, post_cities_adaptor, post_cities_submission_adaptor,
     },
     schema::{
-        Cities, CityPost, CityRatings, RatingSummary, Submission, SubmissionPatch, SubmissionPost,
-        Submissions,
+        Cities, CitiesWithSummary, CityPost, CityRatings, RatingSummary, Submission,
+        SubmissionPatch, SubmissionPost, Submissions,
     },
 };
 use crate::{
     core::resource::{
         cities::{
             adaptor::get_top_cities_adaptor,
-            schema::{CitiesWithSummary, CityParams, CityWithSummary},
+            schema::{CityParams, CityWithSummary},
             CitiesPathParameters,
         },
         schema::{City, ErrorResponses, ListParameters, PaginationParameters},
@@ -33,12 +33,14 @@ use tracing::debug;
 use utoipa_axum::{router::OpenApiRouter, routes};
 
 const TAG: &str = "city";
+const TOP_CITIES_MAX_COUNT: u64 = 100;
 
 pub fn routes() -> OpenApiRouter {
     OpenApiRouter::new()
         .routes(routes!(get_city))
         .routes(routes!(post_city))
         .routes(routes!(get_cities))
+        .routes(routes!(get_cities_latest_summary))
         .routes(routes!(get_city_ratings))
         .routes(routes!(get_cities_submission))
         .routes(routes!(post_cities_submission))
@@ -97,6 +99,49 @@ async fn get_cities(
     Ok(PageFlow::new(
         Paginatron::new(None, payload.0, list.page(), list.page_size()),
         payload.1.into(),
+    ))
+}
+
+#[utoipa::path(
+  get,
+  path = "/cities/summary/latest",
+  description = "Get all cities with their latest summary.",
+  tag = TAG,
+  params(
+    ListParameters,
+  ),
+  responses(
+    (status = OK, description = "Fetches cities with their latest summary", body = CitiesWithSummary),
+  ))]
+async fn get_cities_latest_summary(
+    Query(list): Query<ListParameters>,
+) -> Result<PageFlow<CitiesWithSummary>, ExecutionError> {
+    let db = database_connect_or_init().await?;
+    let payload = get_cities_latest_summary_adaptor(
+        db,
+        list.order_direction(),
+        &list.sort_by(),
+        list.page(),
+        list.page_size(),
+    )
+    .await
+    .map_err(|e| {
+        debug!("{e}");
+        e
+    })?;
+
+    let cities_with_summaries = payload
+        .1
+        .iter()
+        .map(|(c, s)| CityWithSummary {
+            city: c.clone().into(),
+            summary: s.clone().into(),
+        })
+        .collect::<Vec<CityWithSummary>>();
+
+    Ok(PageFlow::new(
+        Paginatron::new(None, payload.0, list.page(), list.page_size()),
+        CitiesWithSummary(cities_with_summaries),
     ))
 }
 
@@ -221,7 +266,6 @@ async fn get_cities_submissions(
         pagination.page_size(),
     )
     .await?;
-    // .map(|v| Json(json!(v.payload())))
     let submissions = cities_submissions
         .1
         .into_iter()
@@ -294,17 +338,18 @@ async fn patch_cities_submission(
   tag = TAG,
   params(
     ("year" = i32, Path, description = "The year to collect the top cities for",  example = "2024", minimum = 2017, maximum = 2029),
-    ("count" = i32, Path, description = "The number of top cities to collect",  example = "10", minimum = 1, maximum = 25),
+    ("count" = u64, Path, description = "The number of top cities to collect",  example = "10", minimum = 1, maximum = 100),
   ),
   responses(
     (status = OK, description = "Fetches cities with their respective summary", body = CitiesWithSummary),
     ErrorResponses,
   ))]
 async fn get_top_cities(
-    Path((year, count)): Path<(i32, i32)>,
+    Path((year, count)): Path<(i32, u64)>,
     ctx: Context,
 ) -> Result<Json<CitiesWithSummary>, ExecutionError> {
     let db = database_connect_or_init().await?;
+    let count = count.clamp(1, TOP_CITIES_MAX_COUNT);
     let models = get_top_cities_adaptor(db, year, count, ctx).await?;
 
     let payload = models

--- a/lambdas/tests/endpoints/cities.hurl
+++ b/lambdas/tests/endpoints/cities.hurl
@@ -54,3 +54,8 @@ jsonpath "$[0].summary.score" >= {{score_1}}
 jsonpath "$[1].summary.score" >= {{score_2}}
 jsonpath "$[2].summary.score" >= {{score_3}}
 jsonpath "$[3].summary.score" >= {{score_4}}
+
+# Queries the latest city summaries.
+GET {{host}}/cities/summary/latest
+
+HTTP 200

--- a/openapi-3.0.yaml
+++ b/openapi-3.0.yaml
@@ -537,6 +537,56 @@ paths:
                       pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
                     status: '404'
                     title: Item Not Found
+  /cities/summary/latest:
+    get:
+      tags:
+        - city
+      description: Get all cities with their latest summary.
+      operationId: get_cities_latest_summary
+      parameters:
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            maximum: 65536
+            minimum: 1
+          example: 5
+        - name: page_size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            maximum: 100
+            minimum: 1
+          example: 25
+        - name: sort_by
+          in: query
+          required: false
+          schema:
+            type: string
+          example: created_at
+        - name: order_direction
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/OrderDirection'
+          example: desc
+        - name: latest
+          in: query
+          required: false
+          schema:
+            type: boolean
+          example: 'true'
+      responses:
+        '200':
+          description: Fetches cities with their latest summary
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CitiesWithSummary'
   /cities/top/{year}/{count}:
     get:
       tags:
@@ -560,8 +610,8 @@ paths:
           required: true
           schema:
             type: integer
-            format: int32
-            maximum: 25
+            format: int64
+            maximum: 100
             minimum: 1
           example: '10'
       responses:

--- a/openapi-3.1.yaml
+++ b/openapi-3.1.yaml
@@ -477,6 +477,56 @@ paths:
                     pointer: /bnas/ratings/e6aade5a-b343-120b-dbaa-bd916cd99221
                   status: '404'
                   title: Item Not Found
+  /cities/summary/latest:
+    get:
+      tags:
+      - city
+      description: Get all cities with their latest summary.
+      operationId: get_cities_latest_summary
+      parameters:
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int64
+          maximum: 65536
+          minimum: 1
+        example: 5
+      - name: page_size
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int64
+          maximum: 100
+          minimum: 1
+        example: 25
+      - name: sort_by
+        in: query
+        required: false
+        schema:
+          type: string
+        example: created_at
+      - name: order_direction
+        in: query
+        required: false
+        schema:
+          $ref: '#/components/schemas/OrderDirection'
+        example: desc
+      - name: latest
+        in: query
+        required: false
+        schema:
+          type: boolean
+        example: 'true'
+      responses:
+        '200':
+          description: Fetches cities with their latest summary
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CitiesWithSummary'
   /cities/top/{year}/{count}:
     get:
       tags:
@@ -500,8 +550,8 @@ paths:
         required: true
         schema:
           type: integer
-          format: int32
-          maximum: 25
+          format: int64
+          maximum: 100
           minimum: 1
         example: '10'
       responses:


### PR DESCRIPTION
Adds a new endpoint to return the latest summary associated with each
city.

Drive-by:
- Regenerates the `bnaclient`.
- Clamps the `/cities/top` endpoint to restrict the number of cities
  returned between 1 and 100.
