### PR TITLE
Fix POST /cities endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.131.0"
+version = "1.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe1b8c5282bf859170836045296b3cd710b7573aceb909498366bb508a41058e"
+checksum = "5575840a3a6b11f6011463ebe359320dfe5b67babb5e9b06fed6ddf809a9ab40"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -811,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "aws_lambda_events"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6714eb6910c2370e48e739252ebf5024c6609ee83fc74cde50a1764949d17974"
+checksum = "d02c123e89527e7b424f74f52d11be0d17ef2887819323a42dcae1c7630ca53d"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1100,6 +1100,7 @@ dependencies = [
  "serde_with",
  "time",
  "tokio",
+ "tracing-test",
  "uuid",
 ]
 
@@ -1188,6 +1189,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -2846,16 +2856,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
-name = "iri-string"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2966,9 +2966,9 @@ dependencies = [
 
 [[package]]
 name = "lambda_http"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731a62bf6abfb725284454871c73c4e801dc42359f3eecf03e86a98d547c7105"
+checksum = "7b5fc0b7ef9af5e63e348c4b11e7e31eab573603348b7eb9c3e831d8e87c1ecc"
 dependencies = [
  "aws_lambda_events",
  "bytes",
@@ -2991,9 +2991,9 @@ dependencies = [
 
 [[package]]
 name = "lambda_runtime"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcfafa53f881580c291de6a487e7f6d3c5830744fb004581cc82736cac258e2a"
+checksum = "5cc1b380b7fb92ddf3913b01f094c3fcf59e31d995bb609645cd64dcdb56ce63"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -3067,6 +3067,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "tracing-test",
  "url",
  "utoipa",
  "utoipa-axum",
@@ -3419,6 +3420,15 @@ dependencies = [
  "bytecount",
  "memchr",
  "nom 8.0.0",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -4841,11 +4851,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.19.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -4860,9 +4871,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.19.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -5485,9 +5496,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -5589,21 +5600,21 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -5662,6 +5673,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-serde"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5678,15 +5700,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
+ "nu-ansi-term",
  "once_cell",
  "regex-automata",
  "serde",
  "serde_json",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
+ "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a4c448db514d4f24c5ddb9f73f2ee71bfb24c526cf0c570ba142d1119e0051"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5803,9 +5849,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utoipa"
-version = "5.4.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
+checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
 dependencies = [
  "indexmap 2.7.0",
  "serde",
@@ -5829,9 +5875,9 @@ dependencies = [
 
 [[package]]
 name = "utoipa-gen"
-version = "5.4.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
+checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ members = ["bnaclient", "lambdas", "entity", "migration", "effortless"]
 
 [workspace.dependencies]
 async-std = "1.13.2"
-aws_lambda_events = "1.1.3"
+aws_lambda_events = "1.2.0"
 aws-config = "1.8.16"
-aws-sdk-s3 = "1.131.0"
+aws-sdk-s3 = "1.132.0"
 aws-sdk-sqs = "1.98.0"
 axum = "0.8.9"
 axum-extra = "0.12.6"
@@ -26,8 +26,8 @@ entity = { path = "entity" }
 futures = "0.3.32"
 http-serde = "2.0.0"
 itertools = "0.14.0"
-lambda_http = "1.1.3"
-lambda_runtime = "1.1.3"
+lambda_http = "1.2.0"
+lambda_runtime = "1.2.0"
 migration = { path = "migration" }
 nom = "7.1.3"
 once_cell = "1.21.4"
@@ -41,15 +41,16 @@ sea-query = "0.32.7"
 serde = "1.0.228"
 serde_json = "1.0.149"
 serde_plain = "1.0.2"
-serde_with = "3.19.0"
+serde_with = "3.20.0"
 thiserror = "2.0.18"
-tokio = "1.52.2"
-tower-http = "0.6.8"
+tokio = "1.52.3"
+tower-http = "0.6.10"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", default-features = false }
+tracing-test = "0.2.6"
 url = "2.5.8"
 urlencoding = "2.1.3"
-utoipa = "5.4.0"
+utoipa = "5.5.0"
 utoipa-axum = "0.2.0"
 utoipa-swagger-ui = "9.0.2"
 uuid = "1.23.1"
@@ -76,6 +77,7 @@ bnacore = { workspace = true }
 csv = { workspace = true }
 itertools = { workspace = true }
 time = { version = "0.3.45", features = ["formatting"] }
+tracing-test = { workspace = true }
 
 [profile.release]
 # Optimize for size instead of speed

--- a/effortless/src/error.rs
+++ b/effortless/src/error.rs
@@ -30,10 +30,8 @@ pub enum APIErrorSource {
 pub struct APIError {
     /// A unique identifier for this particular occurrence of the problem.
     id: Option<String>,
-    // Cannot use http_serde 2.0.0 until lambda_http upgraded the http crate to 1.0.0.
     /// The HTTP status code applicable to this problem, expressed as a string value.
-    #[serde(with = "http_serde::status_code")]
-    status: StatusCode,
+    status: String,
     /// A short, human-readable summary of the problem
     title: String,
     /// A human-readable explanation specific to this occurrence of the problem
@@ -57,7 +55,7 @@ impl APIError {
     ) -> Self {
         Self {
             id,
-            status,
+            status: status.as_u16().to_string(),
             title: title.to_string(),
             details: details.to_string(),
             source,
@@ -68,7 +66,7 @@ impl APIError {
     pub fn with_parameter(id: Option<String>, parameter: &str, message: &str) -> Self {
         Self {
             id,
-            status: StatusCode::BAD_REQUEST,
+            status: StatusCode::BAD_REQUEST.as_u16().to_string(),
             title: String::from("Invalid Query Sring Parameter"),
             source: Some(APIErrorSource::Parameter(parameter.into())),
             details: message.into(),
@@ -79,7 +77,7 @@ impl APIError {
     pub fn with_pointer(id: Option<String>, pointer: &str, message: &str) -> Self {
         Self {
             id,
-            status: StatusCode::BAD_REQUEST,
+            status: StatusCode::BAD_REQUEST.as_u16().to_string(),
             title: String::from("Invalid Attribute"),
             source: Some(APIErrorSource::Pointer(pointer.into())),
             details: message.into(),
@@ -90,7 +88,7 @@ impl APIError {
     pub fn internal_error(id: Option<String>, title: &str, details: &str, source: &str) -> Self {
         Self {
             id,
-            status: StatusCode::INTERNAL_SERVER_ERROR,
+            status: StatusCode::INTERNAL_SERVER_ERROR.as_u16().to_string(),
             source: Some(APIErrorSource::Pointer(source.into())),
             title: title.into(),
             details: details.into(),
@@ -106,7 +104,7 @@ impl APIError {
     pub fn not_found(id: Option<String>, source: &str, message: &str) -> Self {
         Self {
             id,
-            status: StatusCode::NOT_FOUND,
+            status: StatusCode::NOT_FOUND.as_u16().to_string(),
             title: String::from("Content Not Found"),
             source: Some(APIErrorSource::Pointer(source.into())),
             details: message.into(),
@@ -114,8 +112,8 @@ impl APIError {
     }
 
     /// Returns the APIError status.
-    pub fn status(&self) -> StatusCode {
-        self.status
+    pub fn status(&self) -> String {
+        self.status.clone()
     }
 }
 
@@ -182,9 +180,9 @@ impl From<APIErrors> for Response<Body> {
     /// as the one of the error. Otherwise it will be set to [StatusCode::BAD_REQUEST].
     fn from(value: APIErrors) -> Self {
         let status = if value.errors.len() == 1 {
-            value.errors.first().unwrap().status
+            value.errors.first().unwrap().status.as_bytes()
         } else {
-            StatusCode::BAD_REQUEST
+            StatusCode::BAD_REQUEST.as_str().as_bytes()
         };
         Response::builder()
             .status(status)

--- a/lambdas/Cargo.toml
+++ b/lambdas/Cargo.toml
@@ -41,6 +41,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tower-http = { workspace = true, features = ["trace"] }
 tracing = { workspace = true, features = ["log"] }
 tracing-subscriber = { workspace = true, features = ["fmt"] }
+tracing-test = { workspace = true }
 url = { workspace = true }
 utoipa = { workspace = true, features = ["chrono", "decimal", "uuid", "yaml"] }
 utoipa-axum = { workspace = true }

--- a/lambdas/src/core/resource/cities/adaptor.rs
+++ b/lambdas/src/core/resource/cities/adaptor.rs
@@ -12,7 +12,6 @@ use entity::{
     },
 };
 use sea_orm::{ActiveModelTrait, ActiveValue, DatabaseConnection, IntoActiveModel};
-use serde_json::{json, Value};
 use tracing::info;
 use uuid::Uuid;
 
@@ -80,7 +79,7 @@ pub async fn get_cities_ratings_adaptor(
 pub async fn post_cities_adaptor(
     db: &DatabaseConnection,
     city: CityPost,
-) -> Result<Value, ExecutionError> {
+) -> Result<city::Model, ExecutionError> {
     // Ensure the country is a valid one.
     if fetch_country(db, &city.country).await?.is_none() {
         return Err(ExecutionError::UncoveredCountry(city.country));
@@ -114,7 +113,7 @@ pub async fn post_cities_adaptor(
 
     // And insert a new entry.
     let model = active_model.insert(db).await?;
-    Ok(json!(model))
+    Ok(model)
 }
 
 pub async fn get_cities_submission_adaptor(

--- a/lambdas/src/core/resource/cities/endpoint.rs
+++ b/lambdas/src/core/resource/cities/endpoint.rs
@@ -28,7 +28,6 @@ use axum::{
 use axum_extra::extract::OptionalQuery;
 use entity::wrappers::{city, submission};
 use serde::{self, Deserialize};
-use serde_json::Value;
 use tracing::debug;
 use utoipa_axum::{router::OpenApiRouter, routes};
 
@@ -206,9 +205,18 @@ async fn get_city_ratings(
     (status = CREATED, description = "Creates a new city", body = City),
     ErrorResponses,
   ))]
-async fn post_city(Json(city): Json<city::CityPost>) -> Result<Json<Value>, ExecutionError> {
+async fn post_city(
+    Json(city): Json<city::CityPost>,
+) -> Result<(StatusCode, Json<City>), ExecutionError> {
     let db = database_connect_or_init().await?;
-    post_cities_adaptor(db, city).await.map(Json)
+    post_cities_adaptor(db, city)
+        .await
+        .map_err(|e| {
+            debug!("{e}");
+            e
+        })
+        .map(City::from)
+        .map(|v| (StatusCode::CREATED, Json(v)))
 }
 
 #[utoipa::path(

--- a/lambdas/src/core/resource/schema.rs
+++ b/lambdas/src/core/resource/schema.rs
@@ -1,6 +1,7 @@
 //! Describes the schemas shared accross resources.
 use crate::{DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE};
 use chrono::DateTime;
+use entity::city;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use std::convert::Into;
@@ -105,7 +106,7 @@ pub(crate) struct City {
 }
 
 impl From<entity::city::Model> for City {
-    fn from(value: entity::city::Model) -> Self {
+    fn from(value: city::Model) -> Self {
         Self {
             id: value.id,
             country: value.country.into(),

--- a/lambdas/src/lib.rs
+++ b/lambdas/src/lib.rs
@@ -403,10 +403,12 @@ impl IntoResponse for ExecutionError {
         let api_error = APIError::from(self);
         let api_errors = APIErrors::from(api_error);
         let status = if api_errors.errors.len() == 1 {
-            api_errors.errors().first().unwrap().status()
+            let first = api_errors.errors.first().unwrap();
+            first.status().parse::<u16>().expect("invalid status code")
         } else {
-            StatusCode::BAD_REQUEST
+            StatusCode::BAD_REQUEST.as_u16()
         };
+        // let status = status;
         Response::builder()
             .status(status)
             .header(header::CONTENT_TYPE, "application/json")


### PR DESCRIPTION
The `POST /cities` returns a `200 OK` instead of a `201 Created`. This
patch addresses this issue by updating the return type accordingly and
adding debugging output when needed.

Drive-by:
- Fixes the type of the `status` field of the `APIError` struct. It was
  represented as a HTTPStatusCode struct when the JSON API specification
  mentioned a `String`.
- Updates workspace dependencies.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
